### PR TITLE
FEAT: 회원가입 UI 구현

### DIFF
--- a/src/actions/auth/SignUpServerAction.ts
+++ b/src/actions/auth/SignUpServerAction.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export default async function signupAction(formData: FormData) {
+  const name = formData.get("name");
+  const id = formData.get("id");
+  const password = formData.get("password");
+  const confirmPassword = formData.get("confirmPassword");
+  const birth = formData.get("birth");
+
+  // 1) 빈 값 체크
+  if (!name || !id || !password || !confirmPassword || !birth) {
+    throw new Error("모든 값을 입력해주세요.");
+  }
+  // 2) 비밀번호 길이 검증
+  if (!password || String(password).length < 8) {
+    throw new Error("비밀번호는 8자 이상이어야 합니다.");
+  }
+  // 3) 비밀번호 확인 검증
+  if (password !== confirmPassword) {
+    throw new Error("비밀번호가 일치하지 않습니다.");
+  }
+
+  redirect("/login");
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,3 +1,9 @@
+import SignUpForm from "@/components/auth/signup/SignUpForm";
+
 export default function SignUpPage() {
-  return <div></div>;
+  return (
+    <div className="bg-fitlog-50 flex min-h-screen items-center justify-center">
+      <SignUpForm />
+    </div>
+  );
 }

--- a/src/components/auth/signup/SignUpForm.tsx
+++ b/src/components/auth/signup/SignUpForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import Input from "@/components/ui/Input";
+import { Eye, EyeOff } from "lucide-react";
+import ActionButton from "@/components/ui/ActionButton";
+import FitlogLogo from "@/components/ui/FitLogLogo";
+import useSignUp from "@/hooks/useSignUp";
+import signupAction from "@/actions/auth/SignUpServerAction";
+
+export default function SignUpForm() {
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] =
+    useState<boolean>(false);
+
+  const {
+    signupFormData,
+    isSamePassword,
+    handleSignUpChange,
+    isPasswordLengthValid,
+    isFormValid,
+    isBirthValid,
+  } = useSignUp();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (!isFormValid) {
+      e.preventDefault();
+    }
+    console.log("회원가입 성공", signupFormData);
+  };
+
+  return (
+    <form action={signupAction} onSubmit={handleSubmit}>
+      <div className="flex h-194 w-96 flex-col items-center rounded-xl bg-white border-fitlog-beige border shadow-fitlog-form">
+        <div className="flex flex-row items-center justify-center py-14">
+          <FitlogLogo size={48} />
+          <p className="text-fitlog-500 text-4xl font-extrabold ml-4">FitLog</p>
+        </div>
+
+        <div className="flex w-full flex-col px-8">
+          <p className="mb-2 ml-1">이름</p>
+          <Input
+            type="text"
+            placeholder="이름"
+            className="w-full px-3"
+            required
+            name="name"
+            onChange={handleSignUpChange}
+          />
+        </div>
+        <div className="mt-6 flex w-full flex-col px-8">
+          <p className="mb-2 ml-1">아이디</p>
+          <Input
+            type="text"
+            placeholder="아이디"
+            className="w-full px-3"
+            required
+            name="id"
+            onChange={handleSignUpChange}
+          />
+        </div>
+        <div className="mt-6 flex w-full flex-col px-8">
+          <p className="mb-2 ml-1">비밀번호</p>
+          <div className="relative w-full">
+            <Input
+              type={showPassword ? "text" : "password"}
+              placeholder="비밀번호"
+              className="w-full pr-10 px-3"
+              required
+              name="password"
+              onChange={handleSignUpChange}
+            />
+            {showPassword ? (
+              <EyeOff
+                onClick={() => setShowPassword(false)}
+                className="text-fitlog-beige absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer stroke-1 hover:text-[#d7d0ce]"
+              />
+            ) : (
+              <Eye
+                onClick={() => setShowPassword(true)}
+                className="text-fitlog-beige absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer stroke-1 hover:text-[#d7d0ce]"
+              />
+            )}
+          </div>
+          {signupFormData.password.length > 0 && !isPasswordLengthValid && (
+            <p className="text-red-500 text-xs mt-1 ml-1">
+              * 비밀번호는 8자 이상이어야 합니다.
+            </p>
+          )}
+        </div>
+        <div className="mt-6 flex w-full flex-col px-8">
+          <p className="mb-2 ml-1">비밀번호 확인</p>
+          <div className="relative w-full">
+            <Input
+              type={showConfirmPassword ? "text" : "password"}
+              placeholder="비밀번호 확인"
+              className="w-full pr-10 px-3"
+              required
+              name="confirmPassword"
+              onChange={handleSignUpChange}
+            />
+            {showConfirmPassword ? (
+              <EyeOff
+                onClick={() => setShowConfirmPassword(false)}
+                className="text-fitlog-beige absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer stroke-1 hover:text-[#d7d0ce]"
+              />
+            ) : (
+              <Eye
+                onClick={() => setShowConfirmPassword(true)}
+                className="text-fitlog-beige absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer stroke-1 hover:text-[#d7d0ce]"
+              />
+            )}
+          </div>
+          {signupFormData.confirmPassword.length > 0 && !isSamePassword && (
+            <p className="text-red-500 text-xs mt-1 ml-1">
+              * 비밀번호가 일치하지 않습니다.
+            </p>
+          )}
+        </div>
+
+        <div className="mt-6  flex w-full flex-col px-8">
+          <p className="mb-2 ml-1">생년월일</p>
+          <Input
+            type="date"
+            placeholder="YYYY.MM.DD"
+            className="w-full px-3"
+            required
+            name="birth"
+            onChange={handleSignUpChange}
+          />
+          {!signupFormData.birth && !isBirthValid && (
+            <p className="text-red-500 text-sm mt-1">
+              * 올바른 생년월일을 입력해주세요.
+            </p>
+          )}
+        </div>
+        <div className="mt-7 flex w-full flex-col px-8">
+          <ActionButton className="px-3 py-2.5" type="submit">
+            회원가입
+          </ActionButton>
+          <div className="mt-5 flex flex-row justify-center text-sm">
+            <p>이미 계정이 있으신가요?</p>
+            <Link
+              href={"/login"}
+              className="text-fitlog-500 hover:text-fitlog-700 ml-3 font-bold"
+            >
+              로그인
+            </Link>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -15,9 +15,8 @@ export default function ActionButton({
       disabled={disabled}
       {...props}
       className={cn(
-        "rounded-xl bg-fitlog-500 text-white text-sm transition-colors shadow-fitlog-btn cursor-pointer",
-        "hover:bg-fitlog-700",
-        disabled && "cursor-not-allowed bg-gray-300 text-gray-500",
+        "rounded-xl bg-fitlog-500 text-white text-sm transition-colors shadow-fitlog-btn cursor-pointer hover:bg-fitlog-700",
+        // disabled && "bg-gray-300 text-gray-500 hover:bg-gray-300 cursor-auto",
         error && "bg-red-400 hover:bg-red-500 text-white",
         className
       )}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,22 @@
+import { LoginFormData } from "@/types/auth";
+import { useState } from "react";
+
+export default function useAuthValidation() {
+  const [loginFormData, setLoginFormData] = useState<LoginFormData>({
+    id: "",
+    password: "",
+  });
+
+  const handleLoginChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLoginFormData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  return {
+    loginFormData,
+    setLoginFormData,
+    handleLoginChange,
+  };
+}

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -1,0 +1,46 @@
+import { SignUpFormData } from "@/types/auth";
+import { useState } from "react";
+
+export default function useSignUp() {
+  const [signupFormData, setSignupFormData] = useState<SignUpFormData>({
+    name: "",
+    id: "",
+    password: "",
+    confirmPassword: "",
+    birth: "",
+  });
+
+  const isPasswordLengthValid = signupFormData.password.length >= 8;
+
+  const isSamePassword =
+    signupFormData.password === signupFormData.confirmPassword;
+
+  const isBirthValid = () => {
+    if (!signupFormData.birth) return false;
+
+    const today = new Date();
+    const birthDate = new Date(signupFormData.birth);
+
+    return birthDate <= today;
+  };
+
+  // 모든 검증을 통과한 경우만 true (회원가입 버튼 활성화 조건)
+  const isFormValid = isPasswordLengthValid && isSamePassword && isBirthValid;
+
+  const handleSignUpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSignupFormData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  return {
+    signupFormData,
+    setSignupFormData,
+    isSamePassword,
+    handleSignUpChange,
+    isPasswordLengthValid,
+    isFormValid,
+    isBirthValid,
+  };
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,12 @@
+export interface LoginFormData {
+  id: string;
+  password: string;
+}
+
+export interface SignUpFormData {
+  name: string;
+  id: string;
+  password: string;
+  confirmPassword: string;
+  birth: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #4 

## 📝작업 내용

> - 회원가입 UI 를 구현하였습니다.
> - 회원가입도 추후 서버액션을 통해 구현하면 좋을 것 같아서 서버액션으로 구현했습니다.
> - login, signUp 훅을 커스텀 훅으로 분리했습니다.

### 스크린샷 (선택)
<img width="1710" height="887" alt="image" src="https://github.com/user-attachments/assets/6921510b-6331-4d2d-8288-904257b2c612" />

## 💬리뷰 요구사항(선택)

> 컴포넌트화가 더 필요할 것 같은 부분이 있다면 언제든 말해주세용
