### PR TITLE
FEAT: 로그아웃 UI 및 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
+        "@reduxjs/toolkit": "^2.11.1",
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-query-devtools": "^5.91.1",
         "axios": "^1.13.2",
@@ -20,6 +21,8 @@
         "next-fonts": "^1.5.1",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -1715,11 +1718,49 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.1.tgz",
+      "integrity": "sha512-HjhlEREguAyBTGNzRlGNiDHGQ2EjLSPWwdhhpoEqHYy8hWak3Dp6/fU72OfqVsiMb8S6rbfPsWUF24fxpilrVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2135,6 +2176,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.1",
@@ -4944,6 +4991,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.0.1.tgz",
+      "integrity": "sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6678,6 +6735,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -6747,6 +6827,21 @@
         }
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6800,6 +6895,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -7992,6 +8093,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.15",
+    "@reduxjs/toolkit": "^2.11.1",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
     "axios": "^1.13.2",
@@ -21,6 +22,8 @@
     "next-fonts": "^1.5.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "react-redux": "^9.2.0",
+    "redux": "^5.0.1",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/api/logout.ts
+++ b/src/api/logout.ts
@@ -1,0 +1,5 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+
+export async function logoutApi() {
+  return apiClient.post("/auth/logout");
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,8 +86,14 @@
   /* FitLog Interaction Button Drop Shadow (Figma 기준) */
   --shadow-fitlog-btn: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 
+  /* FitLog Interaction Button Shadow - sm size (Figma 기준) */
+  --shadow-fitlog-btn-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+
   /* FitLog Form Drop Shadow (Figma 기준) */
   --shadow-fitlog-form: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+
+  /* action button disabled color */
+  --color-fitlog-disabled: #ababab;
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,18 +35,37 @@ export const metadata: Metadata = {
   description: "Fitlog 메인 페이지",
 };
 
+// export default function RootLayout({ children }: { children: React.ReactNode }) {
+//   return (
+//     <html lang="ko" className={`${nanumSquare.variable}`}>
+//       <body className="bg-fitlog-50 overscroll-none">
+//         <Providers>
+//           {/* 전역 네비바 (/login, /signup 도메인 제외) */}
+//           <NavWrapper />
+
+//           {/* 페이지 내용 */}
+//           <main className="">{children}</main>
+
+//           {/* 포탈 모달 자리 */}
+//           <div id="modal-root" />
+//         </Providers>
+//       </body>
+//     </html>
+//   );
+// }
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko" className={`${nanumSquare.variable}`}>
-      <body className="bg-fitlog-50 min-h-screen overscroll-none">
+      <body className="bg-fitlog-50 overflow-hidden">
         <Providers>
-          {/* 전역 네비바 (/login, /signup 도메인 제외) */}
-          <NavWrapper />
+          {/* 전체를 세로 레이아웃으로 고정 */}
+          <div className="flex h-screen flex-col overflow-hidden">
+            <NavWrapper />
 
-          {/* 페이지 내용 */}
-          <main className="h-[calc(100vh-72px)]">{children}</main>
+            <main className="flex-1 overflow-hidden">{children}</main>
+          </div>
 
-          {/* 포탈 모달 자리 */}
           <div id="modal-root" />
         </Providers>
       </body>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,8 @@
 
 import { AuthProvider } from "@/store/AuthContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider as ReduxProvider } from "react-redux";
+import { store } from "@/store/redux/store";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,8 +20,10 @@ const queryClient = new QueryClient({
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>{children}</AuthProvider>
-    </QueryClientProvider>
+    <ReduxProvider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    </ReduxProvider>
   );
 }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -14,7 +14,7 @@ export default function Navbar() {
       </Link>
 
       {/* 오른쪽 - 유저 아이콘 */}
-      <UserIcon/>
+      <UserIcon />
     </nav>
   );
 }

--- a/src/components/ui/ProfileModal.tsx
+++ b/src/components/ui/ProfileModal.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { Play, User, X } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { LogOut, Play, User, X } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import Image from "next/image";
 import greeting from "@/assets/images/greeting.png";
 import { PopoverClose } from "@radix-ui/react-popover";
 import ActionButton from "@/components/ui/ActionButton";
+import { useLogout } from "@/lib/tanstack/mutation/logout";
 
 export default function UserIcon() {
+  const { mutate: logout, isPending } = useLogout();
+
   return (
     <div>
       <Popover>
@@ -19,7 +26,12 @@ export default function UserIcon() {
             <User className="w-6 h-6 text-gray-600" />
           </button>
         </PopoverTrigger>
-        <PopoverContent side="bottom" align="end" sideOffset={6} className="min-w-80 p-4">
+        <PopoverContent
+          side="bottom"
+          align="end"
+          sideOffset={6}
+          className="min-w-80 p-4"
+        >
           <header className="flex justify-between items-center">
             <p className="font-bold text-md text-gray-600">프로필</p>
             <PopoverClose asChild>
@@ -46,9 +58,16 @@ export default function UserIcon() {
                 <p className="text-sm">아이 니드 프로틴!</p>
               </section>
             </div>
-            <ActionButton className="mt-3 w-full flex items-center justify-center py-2">
+            <ActionButton className="mt-3 w-full flex items-center justify-center py-2 shadow-fitlog-btn-sm">
               <Play className="w-4 h-4 mr-2" />
               수정
+            </ActionButton>
+            <ActionButton
+              onClick={() => logout()}
+              className="mt-3 w-full flex bg-white items-center justify-center py-2 text-fitlog-text border text-sm border-fitlog-beige hover:bg-[#F1F1F1] shadow-fitlog-btn-sm"
+            >
+              <LogOut className="w-4 h-4 mr-2" />
+              {isPending ? "로그아웃 중..." : "로그아웃"}
             </ActionButton>
           </main>
         </PopoverContent>

--- a/src/lib/interceptor/clientInterceptor.ts
+++ b/src/lib/interceptor/clientInterceptor.ts
@@ -36,6 +36,16 @@ apiClient.interceptors.response.use(
     if (error.response?.status !== 401 || !originalRequest) {
       return Promise.reject(error);
     }
+    // 로그아웃 중에는 토큰 재발급 로직 시도하지 못하게 처리
+    const isLogoutCall =
+      typeof originalRequest.url === "string" &&
+      originalRequest.url.includes("/auth/logout");
+
+    if (isLogoutCall) {
+      tokenStore.clear();
+      authEvents.emitLogout();
+      return Promise.reject(error);
+    }
 
     // refresh 요청 자체가 401이면 -> 로그아웃 처리
     const isRefreshCall =

--- a/src/lib/tanstack/mutation/logout.ts
+++ b/src/lib/tanstack/mutation/logout.ts
@@ -10,7 +10,7 @@ export function useLogout() {
     mutationFn: logoutApi,
     onSuccess: () => {
       queryClient.clear();
-      router.push("/login");
+      router.replace("/login");
     },
   });
 }

--- a/src/lib/tanstack/mutation/logout.ts
+++ b/src/lib/tanstack/mutation/logout.ts
@@ -1,0 +1,16 @@
+import { logoutApi } from "@/api/logout";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+export function useLogout() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logoutApi,
+    onSuccess: () => {
+      queryClient.clear();
+      router.push("/login");
+    },
+  });
+}

--- a/src/store/AuthContext.tsx
+++ b/src/store/AuthContext.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from "react";
 import { tokenStore } from "@/store/tokenStore";
+import { authEvents } from "@/store/authEvents";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 type User = { loginId: string; name: string };
 
@@ -18,6 +27,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
 
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
   const setAuth = (token: string, userData: User | null) => {
     tokenStore.set(token);
     setAccessToken(token);
@@ -29,6 +41,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAccessToken(null);
     setUser(null);
   };
+
+  useEffect(() => {
+    authEvents.setLogoutListener(() => {
+      clearAuth();
+      queryClient.clear();
+      router.replace("/login");
+    });
+  }, [queryClient, router]);
 
   return (
     <AuthContext.Provider value={{ accessToken, user, setAuth, clearAuth }}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #13 

## 📝작업 내용

> - 프로필 모달 '수정' 버튼 아래에 '로그아웃' 버튼을 추가하였습니다.
> - 로그아웃 시 쿠키와 DB에 refresh token이 제거되면서 `/login` 페이지로 리다이렉트됩니다.
> - 기존 '수정' 버튼의 shadow를 조금 옅게하기 위해 커스텀 css를 추가하여 `shadow-fitlog-btn-sm`로 변경하였습니다.
>
> - layout.ts
>    - 세부화면을 구현하던 도중, mock data가 길어질 수록 화면 아래 빈 여백이 mock data 갯수만큼 늘어나서 layout.ts 에 css를 조금 수정했습니다.
>    - NavBar 있는 페이지에서 NavBar의 크기만큼 화면 아래로 스크롤되는 현상이 있어서 이를 방지하고자 css를 수정했습니다.

### 스크린샷 (선택)
<img width="368" height="440" alt="image" src="https://github.com/user-attachments/assets/dd27725f-e830-4a30-aede-82b214e5ef6c" />

## 💬리뷰 요구사항(선택)
> UserIcon 컴포넌트 명을 컴포넌트 파일명과 동일하게 ProfileModal로 바꾸려고 하는데 괜찮을까요?? 
> `export default function UserIcon() { }`-> `export default function ProfileModal() { }`