### PR TITLE
FEAT: 세부화면 UI 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,37 +35,16 @@ export const metadata: Metadata = {
   description: "Fitlog 메인 페이지",
 };
 
-// export default function RootLayout({ children }: { children: React.ReactNode }) {
-//   return (
-//     <html lang="ko" className={`${nanumSquare.variable}`}>
-//       <body className="bg-fitlog-50 overscroll-none">
-//         <Providers>
-//           {/* 전역 네비바 (/login, /signup 도메인 제외) */}
-//           <NavWrapper />
-
-//           {/* 페이지 내용 */}
-//           <main className="">{children}</main>
-
-//           {/* 포탈 모달 자리 */}
-//           <div id="modal-root" />
-//         </Providers>
-//       </body>
-//     </html>
-//   );
-// }
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko" className={`${nanumSquare.variable}`}>
-      <body className="bg-fitlog-50 overflow-hidden">
+      <body className="bg-fitlog-50 overscroll-none">
         <Providers>
-          {/* 전체를 세로 레이아웃으로 고정 */}
-          <div className="flex h-screen flex-col overflow-hidden">
+          <div>
             <NavWrapper />
 
-            <main className="flex-1 overflow-hidden">{children}</main>
+            <main>{children}</main>
           </div>
-
           <div id="modal-root" />
         </Providers>
       </body>

--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -1,0 +1,23 @@
+"server-only";
+
+import Timer from "@/components/todos/Timer";
+import TodosContainer from "@/components/todos/TodosContainer";
+import BackToMainButton from "@/components/ui/BackToMainButton";
+
+export default function TodosPage() {
+  return (
+    <div className="flex h-screen flex-col px-28">
+      <BackToMainButton />
+
+      <div className="grid w-full grid-cols-1 gap-16 px-32 pt-40 lg:grid-cols-2">
+        <section className="flex justify-center">
+          <TodosContainer />
+        </section>
+
+        <section className="flex items-center justify-center">
+          <Timer />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/todos/FinishButton.tsx
+++ b/src/components/todos/FinishButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import ActionButton from "@/components/ui/ActionButton";
+import { useRouter } from "next/navigation";
+
+export default function FinishButton() {
+  const router = useRouter();
+  const handleIsDone = () => {
+    router.push("/");
+  };
+  return (
+    <ActionButton onClick={handleIsDone} className="w-full py-3.5 mt-8">
+      운동 완료
+    </ActionButton>
+  );
+}

--- a/src/components/todos/Timer.tsx
+++ b/src/components/todos/Timer.tsx
@@ -69,7 +69,7 @@ export default function Timer() {
   };
 
   return (
-    <div className="static lg:fixed lg:top-60">
+    <div className="static lg:fixed lg:top-1/2 lg:-translate-y-1/2">
       <div className="flex h-89 items-center rounded-xl border border-fitlog-beige bg-white p-10">
         <div className="w-114">
           <div className="rounded-xl bg-gray-100 py-14 text-center">
@@ -107,7 +107,7 @@ export default function Timer() {
             </ActionButton>
             <ActionButton
               onClick={handleReset}
-              disabled={!isActive}
+              // disabled={!isActive}
               className="flex w-full items-center justify-center py-2.5 bg-white border border-fitlog-beige text-fitlog-text shadow-fitlog-btn-sm hover:bg-[#F1F1F1] disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
             >
               <RotateCcw className="mr-2 h-4 w-4" />

--- a/src/components/todos/Timer.tsx
+++ b/src/components/todos/Timer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Play, Square, RotateCcw, Pause } from "lucide-react";
+import ActionButton from "@/components/ui/ActionButton";
+import { useState, useRef, useEffect } from "react";
+import FinishButton from "@/components/todos/FinishButton";
+import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
+import { stopRest } from "@/store/redux/features/todos/timerSlice";
+
+export default function Timer() {
+  const [time, setTime] = useState<number>(0);
+  const [isRunning, setIsRunning] = useState<boolean>(false);
+  const [records, setRecords] = useState<number[]>([]);
+
+  const dispatch = useAppDispatch();
+  const { isActive, duration } = useAppSelector((state) => state.timer);
+
+  useEffect(() => {
+    if (!isActive) return;
+    setTime(duration);
+    setIsRunning(false);
+  }, [isActive, duration]);
+
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const formatTime = (milliseconds: number) => {
+    const totalSeconds = Math.floor(milliseconds / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const ms = Math.floor((milliseconds % 1000) / 10);
+    return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
+  };
+
+  useEffect(() => {
+    if (isRunning) {
+      intervalRef.current = setInterval(() => {
+        setTime((prevTime) => prevTime + 10);
+      }, 10);
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRunning]);
+
+  const handleRunning = () => {
+    setIsRunning(!isRunning);
+  };
+
+  const handleRecord = () => {
+    if (time > 0) {
+      const seconds = Math.floor(time / 1000);
+      setRecords((prev) => [...prev, seconds]);
+      console.log(records);
+      setTime(0);
+      setIsRunning(false);
+    }
+    dispatch(stopRest());
+  };
+
+  const handleReset = () => {
+    setIsRunning(false);
+    setTime(0);
+  };
+
+  return (
+    <div className="static lg:fixed lg:top-60">
+      <div className="flex h-89 items-center rounded-xl border border-fitlog-beige bg-white p-10">
+        <div className="w-114">
+          <div className="rounded-xl bg-gray-100 py-14 text-center">
+            <p className="text-md font-bold text-gray-500">Rest Time</p>
+            <div className="mt-5 items-center justify-center font-mono text-5xl font-bold text-gray-400">
+              {formatTime(time)}
+            </div>
+          </div>
+          <div className="mt-8" />
+          <div className="grid grid-cols-3 gap-3">
+            <ActionButton
+              onClick={handleRunning}
+              disabled={!isActive}
+              className="flex w-full items-center justify-center py-2.5 shadow-fitlog-btn-sm disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
+            >
+              {!isRunning ? (
+                <>
+                  <Play className="mr-2 h-4 w-4" />
+                  시작
+                </>
+              ) : (
+                <>
+                  <Pause className="mr-2 h-4 w-4" />
+                  일시정지
+                </>
+              )}
+            </ActionButton>
+            <ActionButton
+              onClick={handleRecord}
+              disabled={!isActive}
+              className="flex w-full items-center justify-center py-2.5 bg-fitlog-400 shadow-fitlog-btn-sm hover:bg-[#CC595F] disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
+            >
+              <Square className="mr-2 h-4 w-4" />
+              기록
+            </ActionButton>
+            <ActionButton
+              onClick={handleReset}
+              disabled={!isActive}
+              className="flex w-full items-center justify-center py-2.5 bg-white border border-fitlog-beige text-fitlog-text shadow-fitlog-btn-sm hover:bg-[#F1F1F1] disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
+            >
+              <RotateCcw className="mr-2 h-4 w-4" />
+              초기화
+            </ActionButton>
+          </div>
+        </div>
+      </div>
+      <FinishButton />
+    </div>
+  );
+}

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -1,0 +1,24 @@
+"server-only";
+
+import TodoSetRow from "@/components/todos/TodoSetRow";
+import { Todo } from "@/types/todos";
+
+export default function TodoItem({ exerciseName, sets, todoId }: Todo) {
+  return (
+    <div className="w-141 min-h-3 flex flex-col bg-white p-4 py-5 border border-fitlog-beige rounded-[20px] mt-4 first:mt-0 ">
+      <p className="ml-2 mt-2 font-bold">{exerciseName}</p>
+
+      <div className="mt-2 flex flex-col gap-4">
+        {sets.map((set, index) => (
+          <TodoSetRow
+            key={`${todoId}-${index}`}
+            setNumber={index + 1}
+            isCompleted={set.isCompleted}
+            todoId={todoId}
+            setId={set.setId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/todos/TodoSetRow.tsx
+++ b/src/components/todos/TodoSetRow.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import ActionButton from "@/components/ui/ActionButton";
+import Checkbox from "@/components/ui/CheckBox";
+import Input from "@/components/ui/Input";
+import { useState } from "react";
+import { useAppDispatch } from "@/store/redux/hooks";
+import { todoSetCompleted } from "@/store/redux/features/todos/todoSlice";
+import { startRest } from "@/store/redux/features/todos/timerSlice";
+
+interface TodoSetRowProps {
+  todoId: number;
+  setId: number;
+  setNumber: number;
+  isCompleted: boolean;
+}
+
+export default function TodoSetRow({
+  setNumber,
+  isCompleted,
+  todoId,
+  setId,
+}: TodoSetRowProps) {
+  const [isResting, setIsResting] = useState<boolean>(false);
+  const dispatch = useAppDispatch();
+  const handleCompleted = () => {
+    dispatch(todoSetCompleted({ todoId, setId }));
+  };
+
+  const handleStartResting = () => {
+    dispatch(startRest(0));
+    setIsResting(true);
+  };
+
+  return (
+    <div className="flex flex-row gap-3 justify-center items-center">
+      <Checkbox checked={isCompleted} onChange={handleCompleted} />
+      <p className="font-bold w-12">Set {setNumber}</p>
+
+      <Input
+        disabled={isCompleted}
+        className="w-31 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
+        placeholder="10회"
+      />
+      <Input
+        disabled={isCompleted}
+        className="w-31 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
+        placeholder="0kg"
+      />
+      <Input
+        disabled={isCompleted}
+        className="w-19 h-9 rounded-xl px-3 text-center shadow-fitlog-btn-sm"
+        placeholder="-"
+      />
+
+      <ActionButton
+        onClick={handleStartResting}
+        disabled={!isCompleted || isResting}
+        className={`flex items-center justify-center w-17 h-9 rounded-xl shadow-fitlog-btn-sm
+          ${
+            isResting
+              ? "bg-fitlog-500 text-white cursor-default"
+              : "bg-white border border-fitlog-500/60 text-fitlog-500 hover:bg-fitlog-100"
+          }
+          ${!isCompleted ? "" : ""}
+        `}
+      >
+        휴식
+        <ChevronRight className="w-3 ml-1" />
+      </ActionButton>
+    </div>
+  );
+}

--- a/src/components/todos/TodoSetRow.tsx
+++ b/src/components/todos/TodoSetRow.tsx
@@ -37,23 +37,44 @@ export default function TodoSetRow({
     <div className="flex flex-row gap-3 justify-center items-center">
       <Checkbox checked={isCompleted} onChange={handleCompleted} />
       <p className="font-bold w-12">Set {setNumber}</p>
-      <Input
-        disabled={isCompleted}
-        className="w-23 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
-        placeholder="10"
-      />
+      <div
+        className={`w-23 h-9 px-3 text-sm rounded-xl border shadow-fitlog-btn-sm
+    flex items-center justify-center
+    ${
+      isCompleted
+        ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
+        : "border-fitlog-beige text-fitlog-text"
+    }
+  `}
+      >
+        10
+      </div>
       회
-      <Input
-        disabled={isCompleted}
-        className="w-23 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
-        placeholder="0"
-      />
+      <div
+        className={`w-23 h-9 px-3 text-sm rounded-xl border shadow-fitlog-btn-sm
+    flex items-center justify-center
+    ${
+      isCompleted
+        ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
+        : "border-fitlog-beige text-fitlog-text"
+    }
+  `}
+      >
+        0
+      </div>
       kg
-      <Input
-        disabled={isCompleted}
-        className="w-15 h-9 rounded-xl px-3 text-center shadow-fitlog-btn-sm"
-        placeholder="-"
-      />
+      <div
+        className={`w-15 h-9 px-3 text-sm rounded-xl border shadow-fitlog-btn-sm
+          flex items-center justify-center
+          ${
+            isCompleted
+              ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
+              : "border-fitlog-beige text-fitlog-text"
+          }
+        `}
+      >
+        -
+      </div>
       초
       <ActionButton
         onClick={handleStartResting}
@@ -61,10 +82,10 @@ export default function TodoSetRow({
         className={`flex items-center justify-center w-17 h-9 rounded-xl shadow-fitlog-btn-sm
           ${
             isResting
-              ? "bg-fitlog-500 text-white cursor-default"
+              ? "bg-fitlog-500 text-white hover:bg-fitlog-500 cursor-auto"
               : "bg-white border border-fitlog-500/60 text-fitlog-500 hover:bg-fitlog-100"
           }
-          ${!isCompleted ? "" : ""}
+          ${!isCompleted ? "cursor-not-allowed  hover:bg-white! " : ""}
         `}
       >
         휴식

--- a/src/components/todos/TodoSetRow.tsx
+++ b/src/components/todos/TodoSetRow.tsx
@@ -37,23 +37,24 @@ export default function TodoSetRow({
     <div className="flex flex-row gap-3 justify-center items-center">
       <Checkbox checked={isCompleted} onChange={handleCompleted} />
       <p className="font-bold w-12">Set {setNumber}</p>
-
       <Input
         disabled={isCompleted}
-        className="w-31 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
-        placeholder="10회"
+        className="w-23 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
+        placeholder="10"
       />
+      회
       <Input
         disabled={isCompleted}
-        className="w-31 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
-        placeholder="0kg"
+        className="w-23 h-9 rounded-xl px-3 shadow-fitlog-btn-sm"
+        placeholder="0"
       />
+      kg
       <Input
         disabled={isCompleted}
-        className="w-19 h-9 rounded-xl px-3 text-center shadow-fitlog-btn-sm"
+        className="w-15 h-9 rounded-xl px-3 text-center shadow-fitlog-btn-sm"
         placeholder="-"
       />
-
+      초
       <ActionButton
         onClick={handleStartResting}
         disabled={!isCompleted || isResting}

--- a/src/components/todos/TodosContainer.tsx
+++ b/src/components/todos/TodosContainer.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import TodoItem from "@/components/todos/TodoItem";
+import { setTodos } from "@/store/redux/features/todos/todoSlice";
+import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
+import { useEffect } from "react";
+
+const mockData = [
+  {
+    todoId: 1,
+    exerciseName: "스쿼트",
+    sets: [
+      { setId: 1, isCompleted: true },
+      { setId: 2, isCompleted: false },
+      { setId: 3, isCompleted: false },
+    ],
+  },
+  {
+    todoId: 2,
+    exerciseName: "벤치프레스",
+    sets: [
+      { setId: 1, isCompleted: false },
+      { setId: 2, isCompleted: false },
+    ],
+  },
+  {
+    todoId: 3,
+    exerciseName: "스쿼트",
+    sets: [
+      { setId: 1, isCompleted: false },
+      { setId: 2, isCompleted: false },
+      { setId: 3, isCompleted: false },
+    ],
+  },
+  {
+    todoId: 4,
+    exerciseName: "벤치프레스",
+    sets: [
+      { setId: 1, isCompleted: false },
+      { setId: 2, isCompleted: false },
+    ],
+  },
+  {
+    todoId: 5,
+    exerciseName: "벤치프레스",
+    sets: [
+      { setId: 1, isCompleted: false },
+      { setId: 2, isCompleted: false },
+      { setId: 3, isCompleted: false },
+    ],
+  },
+  {
+    todoId: 6,
+    exerciseName: "스쿼트",
+    sets: [
+      { setId: 1, isCompleted: false },
+      { setId: 2, isCompleted: false },
+      { setId: 3, isCompleted: false },
+    ],
+  },
+];
+
+export default function TodosContainer() {
+  const dispatch = useAppDispatch();
+  const todos = useAppSelector((state) => state.todos.todos);
+
+  useEffect(() => {
+    dispatch(setTodos(mockData));
+  }, [dispatch]);
+
+  return (
+    <div className="flex flex-col">
+      <p className="mt-5 mb-3 text-center text-lg font-semibold">운동 목표</p>
+
+      <div className="pb-4">
+        {todos.map((todo) => (
+          <TodoItem
+            key={todo.todoId}
+            todoId={todo.todoId}
+            exerciseName={todo.exerciseName}
+            sets={todo.sets}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -20,12 +20,11 @@ export default function ActionButton({
       className={cn(
         "rounded-xl bg-fitlog-500 text-white text-sm transition-colors shadow-fitlog-btn cursor-pointer hover:bg-fitlog-700",
 
-        // disabled && "bg-gray-300 text-gray-500 hover:bg-gray-300 cursor-auto",
         // variant에 따른 스타일
         variant === "primary" && "bg-fitlog-500 text-white hover:bg-fitlog-700",
-        variant === "secondary" && "bg-white text-black border border-gray-300 hover:bg-gray-100",
-        disabled &&
-          "bg-fitlog-700 text-gray-300 cursor-not-allowed hover:bg-fitlog-900 hover:none disabled:hover:bg-fitlog-900 disabled:pointer-events-none",
+        variant === "secondary" &&
+          "bg-white text-black border border-gray-300 hover:bg-gray-100",
+        disabled && "bg-fitlog-700 text-gray-300 cursor-not-allowed",
 
         error && "bg-red-400 hover:bg-red-500 text-white",
         className

--- a/src/components/ui/BackToMainButton.tsx
+++ b/src/components/ui/BackToMainButton.tsx
@@ -1,0 +1,18 @@
+"server-only";
+
+import { ArrowLeft } from "lucide-react";
+import ActionButton from "@/components/ui/ActionButton";
+import Link from "next/link";
+
+export default function BackToMainButton() {
+  return (
+    <div className="absolute mt-28 left-32">
+      <Link href={"/"}>
+        <ActionButton className="py-2.5 px-5 flex flex-row">
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          뒤로
+        </ActionButton>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/ui/CheckBox.tsx
+++ b/src/components/ui/CheckBox.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/cn";
+import { CheckIcon } from "lucide-react";
+
+interface CheckboxProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type"
+> {}
+
+export default function Checkbox({
+  className,
+  disabled,
+  ...props
+}: CheckboxProps) {
+  return (
+    <label className="inline-flex items-center">
+      <input
+        type="checkbox"
+        disabled={disabled}
+        className="peer sr-only"
+        {...props}
+      />
+
+      <span
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs transition-all",
+          "border-input bg-background text-transparent",
+          "peer-checked:bg-fitlog-500 peer-checked:border-fitlog-500 peer-checked:text-white",
+          "peer-focus-visible:ring-[3px] peer-focus-visible:ring-ring/50",
+          "peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+          className
+        )}
+      >
+        <CheckIcon className="size-3.5" />
+      </span>
+    </label>
+  );
+}

--- a/src/store/redux/features/todos/timerSlice.ts
+++ b/src/store/redux/features/todos/timerSlice.ts
@@ -1,0 +1,25 @@
+import { Timer } from "@/types/timer";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+const initialState: Timer = {
+  isActive: false,
+  duration: 0,
+};
+
+const timerSlice = createSlice({
+  name: "timer",
+  initialState,
+  reducers: {
+    startRest(state, action: PayloadAction<number>) {
+      state.isActive = true;
+      state.duration = action.payload;
+    },
+    stopRest(state) {
+      state.isActive = false;
+      state.duration = 0;
+    },
+  },
+});
+
+export const { startRest, stopRest } = timerSlice.actions;
+export default timerSlice.reducer;

--- a/src/store/redux/features/todos/todoSlice.ts
+++ b/src/store/redux/features/todos/todoSlice.ts
@@ -1,0 +1,36 @@
+import { Todo, Todos } from "@/types/todos";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+const initialState: Todos = {
+  todos: [],
+};
+
+interface TodoSetCompletedPayload {
+  todoId: number;
+  setId: number;
+}
+
+const todosSlice = createSlice({
+  name: "todos",
+  initialState,
+  reducers: {
+    todoSetCompleted(state, action: PayloadAction<TodoSetCompletedPayload>) {
+      const { todoId, setId } = action.payload;
+
+      const todo = state.todos.find((todo) => todo.todoId === todoId);
+      if (!todo) return;
+
+      const set = todo.sets.find((set) => set.setId === setId);
+      if (!set) return;
+
+      set.isCompleted = !set.isCompleted;
+    },
+
+    setTodos(state, action: PayloadAction<Todo[]>) {
+      state.todos = action.payload;
+    },
+  },
+});
+
+export const { todoSetCompleted, setTodos } = todosSlice.actions;
+export default todosSlice.reducer;

--- a/src/store/redux/hooks.ts
+++ b/src/store/redux/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/store/redux/store";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/redux/store.ts
+++ b/src/store/redux/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import todosReducer from "@/store/redux/features/todos/todoSlice";
+import timerReducer from "@/store/redux/features/todos/timerSlice";
+
+export const store = configureStore({
+  reducer: {
+    todos: todosReducer,
+    timer: timerReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/types/timer.ts
+++ b/src/types/timer.ts
@@ -1,0 +1,4 @@
+export interface Timer {
+  isActive: boolean;
+  duration: number; // 초
+}

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -1,0 +1,14 @@
+export interface Set {
+  setId: number;
+  isCompleted: boolean;
+}
+
+export interface Todo {
+  todoId: number;
+  exerciseName: string;
+  sets: Set[];
+}
+
+export interface Todos {
+  todos: Todo[];
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #14 

## 📝작업 내용

> - 세부화면 UI
>   - todo item `isCompleted` -> `휴식` 버튼 활성화 (그 전까진 클릭 안 됨)
>   - `기록` 버튼 누를 시 해당 초만큼 기록 될 것 (API 연동 시)
>   - `초기화` 버튼 누를 시 초 리셋
>   - `기록` 버튼 누르면 기존 `휴식` 버튼은 `bg-fitlog-500` 유지되면서 더 이상 클릭 안 됨
>   - `운동 완료` 버튼 누르면 운동 종료 -> `"/"` 로 리다이렉트

### 스크린샷 (선택)

https://github.com/user-attachments/assets/62333575-d6db-40cf-bb5d-b3a0300a6c37




## 💬리뷰 요구사항(선택)

> 피드백 환영입니다
