### PR TITLE
FEAT: 프로필 수정 UI 구현

### DIFF
--- a/src/components/ui/ProfileModal.tsx
+++ b/src/components/ui/ProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, Play, User, X } from "lucide-react";
+import { Camera, LogOut, Play, User } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -12,9 +12,46 @@ import { PopoverClose } from "@radix-ui/react-popover";
 import ActionButton from "@/components/ui/ActionButton";
 import { useLogout } from "@/lib/tanstack/mutation/logout";
 import CloseButton from "@/components/ui/CloseButton";
+import { useState } from "react";
+import Input from "@/components/ui/Input";
+import { Profile } from "@/types/profile";
+
+const mockData = {
+  name: "박준형",
+  age: 28,
+  bio: "테스트",
+  profileImage: "text",
+  birthDate: "2025-12-15",
+};
 
 export default function ProfileModal() {
   const { mutate: logout, isPending } = useLogout();
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [profile, setProfile] = useState<Profile>(mockData);
+  const [profileImage, setProfileImage] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setProfileImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleCancleProfile = () => {
+    setIsEditing(false);
+    setProfile(mockData);
+    setProfileImage(null);
+  };
+
+  const handleSaveProfile = () => {
+    setIsEditing(false);
+    console.log("저장", profile);
+  };
 
   return (
     <div>
@@ -39,37 +76,138 @@ export default function ProfileModal() {
               <CloseButton />
             </PopoverClose>
           </header>
-          <main className="flex flex-col items-center">
-            <Image
-              src={greeting}
-              alt="프로필 사진"
-              className="w-22 h-22 p-1 rounded-full border-2 border-fitlog-100"
-            />
-            <div className="w-full rounded-xl p-3 mt-3 space-y-2 bg-gray-100">
+          <main className="flex flex-col w-full">
+            <div className="flex justify-center">
+              <div className="relative h-22 w-22">
+                <div className="relative h-full w-full overflow-hidden rounded-full border-2 border-fitlog-100">
+                  <Image
+                    src={profileImage ?? greeting}
+                    alt="프로필 사진"
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                {isEditing && (
+                  <>
+                    <input
+                      id="profile-image"
+                      type="file"
+                      accept="image/*"
+                      onChange={handleImageChange}
+                      className="hidden"
+                    />
+                    <label
+                      htmlFor="profile-image"
+                      className="absolute -bottom-1 -right-1 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-fitlog-500 text-white hover:bg-fitlog-600"
+                    >
+                      <Camera className="h-4 w-4" />
+                    </label>
+                  </>
+                )}
+              </div>
+            </div>
+            <div
+              className={`w-full rounded-xl mt-3 space-y-3 ${isEditing ? "bg-white" : "p-3 bg-gray-100"}`}
+            >
               <section>
-                <p className="text-xs text-gray-400">이름</p>
-                <p className="text-sm">박준형</p>
+                <p
+                  className={`text-xs ${isEditing ? "text-fitlog-text" : "text-gray-400"}`}
+                >
+                  이름
+                </p>
+                {isEditing ? (
+                  <Input
+                    type="text"
+                    value={profile.name}
+                    onChange={(e) =>
+                      setProfile((prev) => ({ ...prev, name: e.target.value }))
+                    }
+                    className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
+                  />
+                ) : (
+                  <p className="text-sm">{profile.name}</p>
+                )}
               </section>
               <section>
-                <p className="text-xs text-gray-400">나이</p>
-                <p className="text-sm">28세</p>
+                <p
+                  className={`text-xs ${isEditing ? "text-fitlog-text" : "text-gray-400"}`}
+                >
+                  나이
+                </p>
+                {isEditing ? (
+                  <input
+                    type="date"
+                    value={profile.birthDate}
+                    onChange={(e) =>
+                      setProfile((prev) => ({
+                        ...prev,
+                        birthDate: e.target.value,
+                      }))
+                    }
+                    className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
+                  />
+                ) : (
+                  <p className="text-sm">{profile.age}세</p>
+                )}
               </section>
               <section>
-                <p className="text-xs text-gray-400">자기소개</p>
-                <p className="text-sm">아이 니드 프로틴!</p>
+                <p
+                  className={`text-xs ${isEditing ? "text-fitlog-text" : "text-gray-400"}`}
+                >
+                  자기소개
+                </p>
+                {isEditing ? (
+                  <textarea
+                    value={profile.bio}
+                    rows={2}
+                    onChange={(e) =>
+                      setProfile((prev) => ({
+                        ...prev,
+                        bio: e.target.value,
+                      }))
+                    }
+                    className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
+                  />
+                ) : (
+                  <p className="text-sm">{profile.bio}</p>
+                )}
               </section>
             </div>
-            <ActionButton className="mt-3 w-full flex items-center justify-center py-2 shadow-fitlog-btn-sm">
-              <Play className="w-4 h-4 mr-2" />
-              수정
-            </ActionButton>
-            <ActionButton
-              onClick={() => logout()}
-              className="mt-3 w-full flex bg-white items-center justify-center py-2 text-fitlog-text border text-sm border-fitlog-beige hover:bg-[#F1F1F1] shadow-fitlog-btn-sm"
-            >
-              <LogOut className="w-4 h-4 mr-2" />
-              {isPending ? "로그아웃 중..." : "로그아웃"}
-            </ActionButton>
+
+            {isEditing ? (
+              <div className="mt-3 grid grid-cols-2 gap-2 w-full">
+                <ActionButton
+                  className="bg-white text-fitlog-text flex w-full items-center justify-center py-2 border text-sm border-fitlog-beige hover:bg-[#F1F1F1] shadow-fitlog-btn-sm"
+                  onClick={handleCancleProfile}
+                >
+                  취소
+                </ActionButton>
+                <ActionButton
+                  className="flex w-full items-center justify-center py-2 shadow-fitlog-btn-sm"
+                  onClick={handleSaveProfile}
+                >
+                  저장
+                </ActionButton>
+              </div>
+            ) : (
+              <>
+                <ActionButton
+                  className="mt-3 w-full flex items-center justify-center py-2 shadow-fitlog-btn-sm"
+                  onClick={() => setIsEditing(true)}
+                >
+                  <Play className="w-4 h-4 mr-2" />
+                  수정
+                </ActionButton>
+
+                <ActionButton
+                  onClick={() => logout()}
+                  className="mt-3 w-full flex bg-white items-center justify-center py-2 text-fitlog-text border text-sm border-fitlog-beige hover:bg-[#F1F1F1] shadow-fitlog-btn-sm"
+                >
+                  <LogOut className="w-4 h-4 mr-2" />
+                  {isPending ? "로그아웃 중..." : "로그아웃"}
+                </ActionButton>
+              </>
+            )}
           </main>
         </PopoverContent>
       </Popover>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,7 @@
+export interface Profile {
+  name: string;
+  age: number;
+  bio: string;
+  profileImage: string;
+  birthDate: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #18 

## 📝작업 내용

> 프로필 수정 UI를 구현했습니다.
> - 현재 '취소'를 누르면 기본 Mock data로 되돌아가는데, 이것은 API 연동 후 수정될 사항입니다 (영상 마지막)
> - age 계산도 API 연동 시 birthDate를 변경하면 계산된 age를 내려주기 때문에 해당 age를 렌더링하면 되어서 지금은 그냥 UI로만 놔뒀습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/140bfe6e-491b-4b30-930d-efa90d549d7e


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
