### PR TITLE
FEAT: 프로필 조회, 수정 API 연동

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,49 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+import { Profile, UpdateProfileParams } from "@/types/profile";
+
+// 프로필 조회
+export async function getProfileApi(): Promise<Profile> {
+  const res = await apiClient.get("/profile/me");
+  if (!res.data) {
+    throw new Error("프로필 조회 실패");
+  }
+  return res.data;
+}
+
+// 프로필 수정
+export async function updateProfileApi({
+  payload,
+  profileImage,
+}: UpdateProfileParams): Promise<Profile> {
+  const formData = new FormData();
+
+  // JSON 데이터를 Blob으로 변환하여 추가
+  const profileBlob = new Blob(
+    [
+      JSON.stringify({
+        username: payload.username,
+        birthDate: payload.birthDate,
+        bio: payload.bio,
+      }),
+    ],
+    { type: "application/json" }
+  );
+  formData.append("profile", profileBlob);
+
+  if (profileImage === null) {
+    // 삭제를 위해 빈 Blob 전송하지 않음
+  } else if (profileImage) {
+    formData.append("profileImage", profileImage);
+  }
+
+  const res = await apiClient.put<Profile>("/profile/update", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  if (!res.data) {
+    throw new Error("프로필 수정 실패");
+  }
+  return res.data;
+}

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -16,22 +16,18 @@ export async function updateProfileApi({
   profileImage,
 }: UpdateProfileParams): Promise<Profile> {
   const formData = new FormData();
+  if (payload.username) {
+    formData.append("username", payload.username);
+  }
+  if (payload.birthDate) {
+    formData.append("birthDate", payload.birthDate);
+  }
+  if (payload.bio) {
+    formData.append("bio", payload.bio);
+  }
 
-  // JSON 데이터를 Blob으로 변환하여 추가
-  const profileBlob = new Blob(
-    [
-      JSON.stringify({
-        username: payload.username,
-        birthDate: payload.birthDate,
-        bio: payload.bio,
-      }),
-    ],
-    { type: "application/json" }
-  );
-  formData.append("profile", profileBlob);
-
+  // 이미지 처리
   if (profileImage === null) {
-    // 삭제를 위해 빈 Blob 전송하지 않음
   } else if (profileImage) {
     formData.append("profileImage", profileImage);
   }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-"use client";
+"server-only";
 
 import FitLogLogo from "@/components/ui/FitLogLogo";
 import Link from "next/link";

--- a/src/components/ui/ProfileModal.tsx
+++ b/src/components/ui/ProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Camera, LogOut, Play, User } from "lucide-react";
+import { Camera, LogOut, Play, User, X } from "lucide-react";
 import {
   Popover,
   PopoverContent,
@@ -12,28 +12,50 @@ import { PopoverClose } from "@radix-ui/react-popover";
 import ActionButton from "@/components/ui/ActionButton";
 import { useLogout } from "@/lib/tanstack/mutation/logout";
 import CloseButton from "@/components/ui/CloseButton";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Input from "@/components/ui/Input";
 import { Profile } from "@/types/profile";
-
-const mockData = {
-  name: "박준형",
-  age: 28,
-  bio: "테스트",
-  profileImage: "text",
-  birthDate: "2025-12-15",
-};
+import { useGetProfile } from "@/lib/tanstack/query/profile";
+import { useUpdateProfile } from "@/lib/tanstack/mutation/profile";
 
 export default function ProfileModal() {
-  const { mutate: logout, isPending } = useLogout();
+  const { mutate: logout, isPending: isLogoutPending } = useLogout();
+  const { data: profileData, isLoading } = useGetProfile();
+  const { mutate: updateProfile, isPending: isUpdateProfilePending } =
+    useUpdateProfile();
 
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [profile, setProfile] = useState<Profile>(mockData);
+  const [editProfile, setEditProfile] = useState<Profile | null>(null);
   const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
+  const [isProfileImageReset, setIsProfileImageReset] =
+    useState<boolean>(false);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      // 파일 크기 체크 (5MB)
+      if (file.size > 5 * 1024 * 1024) {
+        alert("파일 크기는 5MB 이하여야 합니다.");
+        return;
+      }
+
+      // 파일 타입 체크
+      const allowedTypes = [
+        "image/jpeg",
+        "image/png",
+        "image/jpg",
+        "image/webp",
+      ];
+      if (!allowedTypes.includes(file.type)) {
+        alert("JPEG, PNG, JPG, WEBP 형식의 이미지만 업로드 가능합니다.");
+        return;
+      }
+
+      setProfileImageFile(file);
+      setIsProfileImageReset(false);
+
+      // 미리보기를 위한 Data URL 생성
       const reader = new FileReader();
       reader.onloadend = () => {
         setProfileImage(reader.result as string);
@@ -44,13 +66,48 @@ export default function ProfileModal() {
 
   const handleCancleProfile = () => {
     setIsEditing(false);
-    setProfile(mockData);
-    setProfileImage(null);
+    if (profileData) {
+      setEditProfile(profileData);
+      setProfileImage(profileData?.profileImage ?? null);
+      setProfileImageFile(null);
+    }
   };
 
   const handleSaveProfile = () => {
+    if (!editProfile) return;
+
+    updateProfile({
+      payload: {
+        username: editProfile.username,
+        birthDate: editProfile.birthDate,
+        bio: editProfile.bio,
+      },
+      profileImage: isProfileImageReset ? null : profileImageFile,
+    });
     setIsEditing(false);
-    console.log("저장", profile);
+    setIsProfileImageReset(false);
+  };
+
+  useEffect(() => {
+    if (profileData) {
+      setEditProfile(profileData);
+
+      const img = profileData.profileImage;
+      setProfileImage(
+        img && (img.startsWith("http") || img.startsWith("data:")) ? img : null
+      );
+      setProfileImageFile(null);
+    }
+  }, [profileData]);
+
+  if (isLoading || !editProfile) {
+    return null;
+  }
+
+  const handleImageDelete = () => {
+    setProfileImage(null);
+    setProfileImageFile(null);
+    setIsProfileImageReset(true);
   };
 
   return (
@@ -58,10 +115,19 @@ export default function ProfileModal() {
       <Popover>
         <PopoverTrigger asChild>
           <button
-            className="p-1 border-2 border-gray-600 rounded-full hover:opacity-60 transition cursor-pointer flex items-center justify-center"
+            className="relative w-8 h-8 rounded-full overflow-hidden border-2 border-gray-600 hover:opacity-60 transition cursor-pointer flex items-center justify-center"
             aria-label="user menu"
           >
-            <User className="w-6 h-6 text-gray-600" />
+            {profileImage ? (
+              <Image
+                src={profileImage}
+                alt="프로필 사진"
+                fill
+                className="object-cover"
+              />
+            ) : (
+              <User className="w-6 h-6 text-gray-600" />
+            )}
           </button>
         </PopoverTrigger>
         <PopoverContent
@@ -73,7 +139,7 @@ export default function ProfileModal() {
           <header className="flex justify-between items-center">
             <p className="font-bold text-md text-gray-600">프로필</p>
             <PopoverClose asChild>
-              <CloseButton />
+              <CloseButton onClick={() => setIsEditing(false)} />
             </PopoverClose>
           </header>
           <main className="flex flex-col w-full">
@@ -92,7 +158,7 @@ export default function ProfileModal() {
                     <input
                       id="profile-image"
                       type="file"
-                      accept="image/*"
+                      accept="image/jpeg,image/png,image/jpg,image/webp"
                       onChange={handleImageChange}
                       className="hidden"
                     />
@@ -102,6 +168,15 @@ export default function ProfileModal() {
                     >
                       <Camera className="h-4 w-4" />
                     </label>
+                    {profileImage && (
+                      <button
+                        onClick={handleImageDelete}
+                        className="absolute -bottom-1 -left-1 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-fitlog-500 text-white hover:bg-fitlog-600"
+                        aria-label="이미지 삭제"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    )}
                   </>
                 )}
               </div>
@@ -118,36 +193,37 @@ export default function ProfileModal() {
                 {isEditing ? (
                   <Input
                     type="text"
-                    value={profile.name}
+                    value={editProfile.username}
                     onChange={(e) =>
-                      setProfile((prev) => ({ ...prev, name: e.target.value }))
+                      setEditProfile((prev) =>
+                        prev ? { ...prev, username: e.target.value } : prev
+                      )
                     }
                     className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
                   />
                 ) : (
-                  <p className="text-sm">{profile.name}</p>
+                  <p className="text-sm">{editProfile.username}</p>
                 )}
               </section>
               <section>
                 <p
                   className={`text-xs ${isEditing ? "text-fitlog-text" : "text-gray-400"}`}
                 >
-                  나이
+                  {isEditing ? "생년월일" : "나이"}
                 </p>
                 {isEditing ? (
                   <input
                     type="date"
-                    value={profile.birthDate}
+                    value={editProfile.birthDate}
                     onChange={(e) =>
-                      setProfile((prev) => ({
-                        ...prev,
-                        birthDate: e.target.value,
-                      }))
+                      setEditProfile((prev) =>
+                        prev ? { ...prev, birthDate: e.target.value } : prev
+                      )
                     }
                     className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
                   />
                 ) : (
-                  <p className="text-sm">{profile.age}세</p>
+                  <p className="text-sm">{editProfile.age}세</p>
                 )}
               </section>
               <section>
@@ -158,18 +234,17 @@ export default function ProfileModal() {
                 </p>
                 {isEditing ? (
                   <textarea
-                    value={profile.bio}
+                    value={editProfile?.bio ?? ""}
                     rows={2}
                     onChange={(e) =>
-                      setProfile((prev) => ({
-                        ...prev,
-                        bio: e.target.value,
-                      }))
+                      setEditProfile((prev) =>
+                        prev ? { ...prev, bio: e.target.value } : prev
+                      )
                     }
                     className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
                   />
                 ) : (
-                  <p className="text-sm">{profile.bio}</p>
+                  <p className="text-sm">{editProfile?.bio}</p>
                 )}
               </section>
             </div>
@@ -185,8 +260,9 @@ export default function ProfileModal() {
                 <ActionButton
                   className="flex w-full items-center justify-center py-2 shadow-fitlog-btn-sm"
                   onClick={handleSaveProfile}
+                  disabled={isUpdateProfilePending}
                 >
-                  저장
+                  {isUpdateProfilePending ? "저장 중..." : "저장"}
                 </ActionButton>
               </div>
             ) : (
@@ -202,9 +278,10 @@ export default function ProfileModal() {
                 <ActionButton
                   onClick={() => logout()}
                   className="mt-3 w-full flex bg-white items-center justify-center py-2 text-fitlog-text border text-sm border-fitlog-beige hover:bg-[#F1F1F1] shadow-fitlog-btn-sm"
+                  disabled={isLogoutPending}
                 >
                   <LogOut className="w-4 h-4 mr-2" />
-                  {isPending ? "로그아웃 중..." : "로그아웃"}
+                  {isLogoutPending ? "로그아웃 중..." : "로그아웃"}
                 </ActionButton>
               </>
             )}

--- a/src/components/ui/ProfileModal.tsx
+++ b/src/components/ui/ProfileModal.tsx
@@ -21,7 +21,7 @@ import { useUpdateProfile } from "@/lib/tanstack/mutation/profile";
 export default function ProfileModal() {
   const { mutate: logout, isPending: isLogoutPending } = useLogout();
   const { data: profileData, isLoading } = useGetProfile();
-  const { mutate: updateProfile, isPending: isUpdateProfilePending } =
+  const { mutateAsync: updateProfile, isPending: isUpdateProfilePending } =
     useUpdateProfile();
 
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -73,19 +73,25 @@ export default function ProfileModal() {
     }
   };
 
-  const handleSaveProfile = () => {
+  const handleSaveProfile = async () => {
     if (!editProfile) return;
 
-    updateProfile({
-      payload: {
-        username: editProfile.username,
-        birthDate: editProfile.birthDate,
-        bio: editProfile.bio,
-      },
-      profileImage: isProfileImageReset ? null : profileImageFile,
-    });
-    setIsEditing(false);
-    setIsProfileImageReset(false);
+    try {
+      await updateProfile({
+        payload: {
+          username: editProfile.username,
+          birthDate: editProfile.birthDate,
+          bio: editProfile.bio,
+        },
+        profileImage: isProfileImageReset ? null : profileImageFile,
+      });
+
+      setIsEditing(false);
+      setIsProfileImageReset(false);
+    } catch (error) {
+      alert("이름은 필수입니다.");
+      console.log(error);
+    }
   };
 
   useEffect(() => {
@@ -188,7 +194,7 @@ export default function ProfileModal() {
                 <p
                   className={`text-xs ${isEditing ? "text-fitlog-text" : "text-gray-400"}`}
                 >
-                  이름
+                  {isEditing ? "이름 *" : "이름"}
                 </p>
                 {isEditing ? (
                   <Input
@@ -202,7 +208,7 @@ export default function ProfileModal() {
                     className="mt-1 w-full border px-2 py-1 text-sm outline-none focus:border-fitlog-400 rounded-lg"
                   />
                 ) : (
-                  <p className="text-sm">{editProfile.username}</p>
+                  <p className="text-sm">{profileData?.username}</p>
                 )}
               </section>
               <section>

--- a/src/lib/tanstack/mutation/logout.ts
+++ b/src/lib/tanstack/mutation/logout.ts
@@ -12,5 +12,8 @@ export function useLogout() {
       queryClient.clear();
       router.replace("/login");
     },
+    onError: () => {
+      alert("로그아웃에 실패했습니다.");
+    },
   });
 }

--- a/src/lib/tanstack/mutation/profile.ts
+++ b/src/lib/tanstack/mutation/profile.ts
@@ -1,0 +1,16 @@
+import { updateProfileApi } from "@/api/profile";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateProfileApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+    },
+    onError: () => {
+      alert("프로필 저장에 실패했습니다.");
+    },
+  });
+}

--- a/src/lib/tanstack/mutation/profile.ts
+++ b/src/lib/tanstack/mutation/profile.ts
@@ -9,8 +9,5 @@ export function useUpdateProfile() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["profile"] });
     },
-    onError: () => {
-      alert("프로필 저장에 실패했습니다.");
-    },
   });
 }

--- a/src/lib/tanstack/query/profile.ts
+++ b/src/lib/tanstack/query/profile.ts
@@ -1,0 +1,11 @@
+import { getProfileApi } from "@/api/profile";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGetProfile() {
+  return useQuery({
+    queryKey: ["profile"],
+    queryFn: getProfileApi,
+    staleTime: 1000 * 60 * 5, // 5분
+    gcTime: 1000 * 60 * 10,
+  });
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,7 +1,16 @@
-export interface Profile {
-  name: string;
-  age: number;
+export interface UpdateProfile {
+  username: string;
   bio: string;
-  profileImage: string;
   birthDate: string;
+}
+
+export interface Profile extends UpdateProfile {
+  age: number;
+  profileImage: string | null;
+}
+
+// 프로필 수정 param을 위한 타입
+export interface UpdateProfileParams {
+  payload: UpdateProfile;
+  profileImage?: File | null;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #20 

## 📝작업 내용

> - 프로필 조회, 수정 API를 연동했습니다.
>    - API 연동하면서 이미지 삭제 (기본 이미지) 기능, 프로필 이미지 변경 시 기존 User icon 위치에 이미지가 들어가도록 UI 수정
>
> - NavBar 클라이언트 컴포넌트 -> 서버 컴포넌트로 변경


### 스크린샷 (선택)

https://github.com/user-attachments/assets/55800dae-4a83-47f3-90e5-a87b5f5d0932

- 이름 null일 때 에러 alert 처리
<img width="661" height="517" alt="image" src="https://github.com/user-attachments/assets/40b98db7-5449-45e7-8104-affdc3e5b31e" />



## 💬리뷰 요구사항(선택)

> 피드백 환영합니다
> - 백엔드 수정사항있어서 백엔드도 곧 올리겠습니다.
