### PR TITLE
FEAT: Calendar 날짜 선택 시 메인 우측 패널 동적 렌더링 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,28 @@
+"use client";
+
 import GoalList from "@/components/main-right/GoalList";
 import { Calendar } from "@/components/main-left/Calendar";
 import FillLevel from "@/components/main-left/FillLevel";
 
 export default function MainPage() {
-  
   return (
     <div className="flex justify-center px-28">
-      <div className="grid w-full max-w-6xl py-24 grid-cols-1 md:grid-cols-2 md:h-[calc(100vh-72px) gap-16">
+      <div className="md:h-[calc(100vh-72px) grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
         {/* LEFT: Calendar */}
         <section className="mt-[72px] flex flex-col items-center">
-          <Calendar className="w-full" />
+          <Calendar
+            className="w-full"
+            // onSelectDate={(date) => {
+            //   console.log("선택한 날짜:", date);
+            // }}
+          />
           <FillLevel className="w-full pt-6" />
         </section>
 
         {/* RIGHT: TodoList */}
         <section className="flex min-h-0 flex-col">
-          <div className="md:flex-1 md:h-full w-full overflow-y-auto min-h-0">
-          <GoalList />
+          <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
+            <GoalList />
           </div>
         </section>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,54 +1,11 @@
 "use client";
 
-import GoalList from "@/components/main-right/GoalList";
-import { Calendar } from "@/components/main-left/Calendar";
-import FillLevel from "@/components/main-left/FillLevel";
-import Greeting from "@/components/main-right/Greeting";
-import RecordList from "@/components/main-right/RecordList";
-import { useState } from "react";
+import MainClient from "@/components/main/MainClient";
 
 export default function MainPage() {
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const [dayStatus, setDayStatus] = useState<{
-    hasTodos: boolean;
-    isDone: boolean;
-  } | null>(null);
-
-  const handleSelectDate = (date: string) => {
-    setSelectedDate(date);
-
-    // 임시 mock 로직
-    if (date === "2025-12-15") {
-      setDayStatus({ hasTodos: true, isDone: false });
-    } else if (date === "2025-12-16") {
-      setDayStatus({ hasTodos: true, isDone: true });
-    } else {
-      setDayStatus({ hasTodos: false, isDone: false });
-    }
-  };
-
   return (
     <div className="flex justify-center px-28">
-      <div className="md:h-[calc(100vh-72px) grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
-        {/* LEFT: Calendar */}
-        <section className="mt-[72px] flex flex-col items-center">
-          <Calendar className="w-full" onSelectDate={handleSelectDate} />
-          <FillLevel className="w-full pt-6" />
-        </section>
-
-        {/* RIGHT: TodoList */}
-        <section className="flex min-h-0 flex-col">
-          <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
-            {!dayStatus && <Greeting username="준형" />}
-
-            {dayStatus && !dayStatus.hasTodos && <Greeting username="준형" />}
-
-            {dayStatus && dayStatus.hasTodos && !dayStatus.isDone && <GoalList />}
-
-            {dayStatus && dayStatus.hasTodos && dayStatus.isDone && <RecordList />}
-          </div>
-        </section>
+      <MainClient />
       </div>
-    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,26 +3,49 @@
 import GoalList from "@/components/main-right/GoalList";
 import { Calendar } from "@/components/main-left/Calendar";
 import FillLevel from "@/components/main-left/FillLevel";
+import Greeting from "@/components/main-right/Greeting";
+import RecordList from "@/components/main-right/RecordList";
+import { useState } from "react";
 
 export default function MainPage() {
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [dayStatus, setDayStatus] = useState<{
+    hasTodos: boolean;
+    isDone: boolean;
+  } | null>(null);
+
+  const handleSelectDate = (date: string) => {
+    setSelectedDate(date);
+
+    // 임시 mock 로직
+    if (date === "2025-12-15") {
+      setDayStatus({ hasTodos: true, isDone: false });
+    } else if (date === "2025-12-16") {
+      setDayStatus({ hasTodos: true, isDone: true });
+    } else {
+      setDayStatus({ hasTodos: false, isDone: false });
+    }
+  };
+
   return (
     <div className="flex justify-center px-28">
       <div className="md:h-[calc(100vh-72px) grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
         {/* LEFT: Calendar */}
         <section className="mt-[72px] flex flex-col items-center">
-          <Calendar
-            className="w-full"
-            // onSelectDate={(date) => {
-            //   console.log("선택한 날짜:", date);
-            // }}
-          />
+          <Calendar className="w-full" onSelectDate={handleSelectDate} />
           <FillLevel className="w-full pt-6" />
         </section>
 
         {/* RIGHT: TodoList */}
         <section className="flex min-h-0 flex-col">
           <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
-            <GoalList />
+            {!dayStatus && <Greeting username="준형" />}
+
+            {dayStatus && !dayStatus.hasTodos && <Greeting username="준형" />}
+
+            {dayStatus && dayStatus.hasTodos && !dayStatus.isDone && <GoalList />}
+
+            {dayStatus && dayStatus.hasTodos && dayStatus.isDone && <RecordList />}
           </div>
         </section>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+"server-only";
 
 import MainClient from "@/components/main/MainClient";
 

--- a/src/components/main-left/Calendar.tsx
+++ b/src/components/main-left/Calendar.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/cn";
 import YearMonthPicker from "@/components/main-left/YearMonthPicker";
 import CalendarCell from "@/components/main-left/CalendarCell";
+import { CalendarProps } from "@/types/calendar";
 
 // 운동 강도 Mock 데이터
 export const workoutIntensity: Record<string, number> = {
@@ -17,11 +18,6 @@ export const workoutIntensity: Record<string, number> = {
   "2025-12-06": 3,
   "2025-12-07": 1,
   "2025-12-09": 3,
-};
-
-type CalendarProps = {
-  className?: string;
-  onSelectDate?: (date: string) => void;
 };
 
 export function Calendar({ className, onSelectDate }: CalendarProps) {

--- a/src/components/main-left/Calendar.tsx
+++ b/src/components/main-left/Calendar.tsx
@@ -105,7 +105,7 @@ export function Calendar({ className, onSelectDate }: CalendarProps) {
   const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   return (
-    <div className={cn("w-full rounded-xl bg-white p-6 shadow border border-gray-200", className)}>
+    <div className={cn("w-full rounded-xl bg-white p-6 shadow border border-fitlog-beige", className)}>
       {/* 상단 월 이동 */}
       <div className="mb-5 flex items-center justify-between">
         <button

--- a/src/components/main-left/Calendar.tsx
+++ b/src/components/main-left/Calendar.tsx
@@ -19,7 +19,12 @@ export const workoutIntensity: Record<string, number> = {
   "2025-12-09": 3,
 };
 
-export function Calendar({ className }: { className?: string }) {
+type CalendarProps = {
+  className?: string;
+  onSelectDate?: (date: string) => void;
+};
+
+export function Calendar({ className, onSelectDate }: CalendarProps) {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
@@ -35,6 +40,19 @@ export function Calendar({ className }: { className?: string }) {
     d.setHours(0, 0, 0, 0);
     return d;
   });
+
+  /* 날짜 선택 핸들러 */
+  const formatDate = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  };
+
+  const handleSelectDate = (date: Date) => {
+    setSelectedDate(date);
+    onSelectDate?.(formatDate(date));
+  };
 
   /* 5주 / 6주 판단 */
   const totalCells = startDay + daysInMonth;
@@ -52,7 +70,7 @@ export function Calendar({ className }: { className?: string }) {
         isCurrentMonth={false}
         selectedDate={selectedDate}
         today={today}
-        onSelect={setSelectedDate}
+        onSelect={handleSelectDate}
       />
     );
   }
@@ -67,7 +85,7 @@ export function Calendar({ className }: { className?: string }) {
         isCurrentMonth={true}
         selectedDate={selectedDate}
         today={today}
-        onSelect={setSelectedDate}
+        onSelect={handleSelectDate}
       />
     );
   }
@@ -83,7 +101,7 @@ export function Calendar({ className }: { className?: string }) {
         isCurrentMonth={false}
         selectedDate={selectedDate}
         today={today}
-        onSelect={setSelectedDate}
+        onSelect={handleSelectDate}
       />
     );
   }

--- a/src/components/main-left/FillLevel.tsx
+++ b/src/components/main-left/FillLevel.tsx
@@ -1,7 +1,7 @@
 const FillLevel = ({ className }: { className?: string }) => {
   return (
     <section className={className}>
-      <div className="bg-card border border-border rounded-2xl p-4 shadow">
+      <div className="bg-card border border-fitlog-beige rounded-2xl p-4 shadow">
         <h3 className="text-lg font-semibold mb-3">활동 수준</h3>
         
         <div className="flex items-center gap-3 flex-wrap text-sm">

--- a/src/components/main-right/ExercisesDropdownButton.tsx
+++ b/src/components/main-right/ExercisesDropdownButton.tsx
@@ -73,7 +73,7 @@ export default function ExercisesDropdownButton({
             side="bottom"
             align="start"
             sideOffset={-44}
-            className="w-[var(--radix-popover-trigger-width)] p-1 rounded-xl border shadow-md"
+            className="w-[var(--radix-popover-trigger-width)] p-1 rounded-xl border border-fitlog-beige shadow-md"
           >
             <input
               autoFocus
@@ -81,10 +81,10 @@ export default function ExercisesDropdownButton({
               placeholder="운동 검색"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full mb-2 px-4 py-2 text-sm rounded-md border focus:outline-none focus:ring-1 focus:ring-fitlog-500"
+              className="w-full mb-2 px-4 py-2 text-sm rounded-md border border-fitlog-beige focus:outline-none focus:border-fitlog-500"
             />
 
-            <ul className="flex flex-col max-h-96 overflow-y-auto">
+            <ul className="flex flex-col max-h-64 overflow-y-auto">
               {items.map((exercise) => (
                 <li
                   key={exercise.id}

--- a/src/components/main-right/Greeting.tsx
+++ b/src/components/main-right/Greeting.tsx
@@ -1,0 +1,20 @@
+import Image from "next/image";
+import React from "react";
+import greetingImg from "@/assets/images/greeting.png";
+
+type GreetingProps = {
+  username: string;
+};
+
+export default function Greeting({ username }: GreetingProps) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-6 rounded-xl bg-white p-8 shadow border border-border">
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-xl font-semibold text-gray-800">{username}님,</p>
+        <p className="text-lg font-medium text-gray-600">오늘도 화이팅이에요! 💪🏻</p>
+      </div>
+
+      <Image src={greetingImg} alt="greeting" width={180} height={180} priority />
+    </div>
+  );
+}

--- a/src/components/main-right/Greeting.tsx
+++ b/src/components/main-right/Greeting.tsx
@@ -8,13 +8,13 @@ type GreetingProps = {
 
 export default function Greeting({ username }: GreetingProps) {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-6 rounded-xl bg-white p-8 shadow border border-border">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-6">
       <div className="flex flex-col items-center gap-2">
         <p className="text-xl font-semibold text-gray-800">{username}님,</p>
-        <p className="text-lg font-medium text-gray-600">오늘도 화이팅이에요! 💪🏻</p>
+        <p className="text-xl font-semibold text-gray-800">오늘도 운동도 화이팅이에요! 💪🏻</p>
       </div>
 
-      <Image src={greetingImg} alt="greeting" width={180} height={180} priority />
+      <Image src={greetingImg} alt="greeting" width={360} height={360} priority />
     </div>
   );
 }

--- a/src/components/main-right/RecordList.tsx
+++ b/src/components/main-right/RecordList.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function RecordList() {
+    return (
+        <div>
+            RecordList
+        </div>
+    );
+};

--- a/src/components/main-right/SetItem.tsx
+++ b/src/components/main-right/SetItem.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Input from "@/components/ui/Input";
-import { X } from "lucide-react";
 import CloseButton from "@/components/ui/CloseButton";
 import { SetItemProps } from "@/types/todoMain";
 
@@ -14,8 +13,7 @@ export default function SetItem({
   return (
     <div className="flex justify-between items-center gap-4 pb-2">
       {/* 세트 번호 */}
-      <h2 className="text-sm w-10">{set.setsNumber}세트</h2>
-
+      <h2 className="font-bold text-md w-10">Set{set.setsNumber}</h2>
       {/* 반복 횟수 입력 */}
       <Input
         type="number"
@@ -27,9 +25,8 @@ export default function SetItem({
             repsTarget: e.target.value === "" ? "" : Number(e.target.value),
           })
         }
-      />회
-      <X className="w-4 h-4" />
-      {/* 중량 입력 */}
+      />
+      회{/* 중량 입력 */}
       <Input
         type="number"
         className="w-16 flex-1 text-center disabled:opacity-100 disabled:bg-white disabled:text-black disabled:cursor-default"
@@ -40,10 +37,12 @@ export default function SetItem({
             weight: e.target.value === "" ? "" : Number(e.target.value),
           })
         }
-      />KG
-
+      />
+      kg
       {/* 세트 삭제 */}
-      <CloseButton onClick={() => onRemoveSet(goalId, set.id)} className="w-5 h-5" />
+      {!completed && (
+        <CloseButton onClick={() => onRemoveSet(goalId, set.id)} className="w-5 h-5" />
+      )}
     </div>
   );
 }

--- a/src/components/main-right/SetItem.tsx
+++ b/src/components/main-right/SetItem.tsx
@@ -13,7 +13,7 @@ export default function SetItem({
   return (
     <div className="flex justify-between items-center gap-4 pb-2">
       {/* 세트 번호 */}
-      <h2 className="font-bold text-md w-10">Set{set.setsNumber}</h2>
+      <h2 className="font-bold text-md w-10">Set {set.setsNumber}</h2>
       {/* 반복 횟수 입력 */}
       <Input
         type="number"

--- a/src/components/main-right/SetList.tsx
+++ b/src/components/main-right/SetList.tsx
@@ -36,7 +36,7 @@ export default function SetList({
 
         {!completed && (
           <ActionButton
-            className="w-full p-2 flex justify-center items-center gap-2 text-md"
+            className="w-full p-2 flex justify-center items-center gap-2 text-md shadow-fitlog-btn-sm"
             variant="secondary"
             onClick={() => onCreateSet(goal.id)}
           >

--- a/src/components/main-right/SetList.tsx
+++ b/src/components/main-right/SetList.tsx
@@ -15,7 +15,7 @@ export default function SetList({
 }: SetListProps) {
   return (
     <div className="SetList">
-      <section className="w-full h-auto rounded-xl p-4 border border-border flex flex-col gap-2 bg-white shadow">
+      <section className="w-full h-auto rounded-xl p-4 border border-fitlog-beige flex flex-col gap-2 bg-white shadow">
         {/* 운동 제목 */}
         <div className="flex justify-between items-center">
           <h1 className="text-md font-semibold">{goal.exercise}</h1>

--- a/src/components/main/MainClient.tsx
+++ b/src/components/main/MainClient.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Calendar } from "@/components/main-left/Calendar";
+import FillLevel from "@/components/main-left/FillLevel";
+import GoalList from "@/components/main-right/GoalList";
+import Greeting from "@/components/main-right/Greeting";
+import RecordList from "@/components/main-right/RecordList";
+
+export default function MainClient() {
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [dayStatus, setDayStatus] = useState<{
+    hasTodos: boolean;
+    isDone: boolean;
+  } | null>(null);
+
+  const handleSelectDate = (date: string) => {
+    setSelectedDate(date);
+
+    // mock
+    if (date === "2025-12-15") {
+      setDayStatus({ hasTodos: true, isDone: false });
+    } else if (date === "2025-12-16") {
+      setDayStatus({ hasTodos: true, isDone: true });
+    } else {
+      setDayStatus({ hasTodos: false, isDone: false });
+    }
+  };
+
+  return (
+    <div className="md:h-[calc(100vh-72px) grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
+      {/* LEFT */}
+      <section className="mt-[72px] flex flex-col items-center">
+        <Calendar className="w-full" onSelectDate={handleSelectDate} />
+        <FillLevel className="w-full pt-6" />
+      </section>
+
+      {/* RIGHT */}
+      <section className="flex min-h-0 flex-col">
+        <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
+          {!dayStatus && <Greeting username="준형" />}
+          {dayStatus && !dayStatus.hasTodos && <Greeting username="준형" />}
+          {dayStatus && dayStatus.hasTodos && !dayStatus.isDone && <GoalList />}
+          {dayStatus && dayStatus.hasTodos && dayStatus.isDone && <RecordList />}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/ui/ActionButton.tsx
+++ b/src/components/ui/ActionButton.tsx
@@ -23,7 +23,7 @@ export default function ActionButton({
         // variant에 따른 스타일
         variant === "primary" && "bg-fitlog-500 text-white hover:bg-fitlog-700",
         variant === "secondary" &&
-          "bg-white text-black border border-gray-300 hover:bg-gray-100",
+          "bg-white text-black border border-fitlog-beige hover:bg-gray-100",
         disabled && "bg-fitlog-700 text-gray-300 cursor-not-allowed",
 
         error && "bg-red-400 hover:bg-red-500 text-white",

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,0 +1,4 @@
+export interface CalendarProps {
+  className?: string;
+  onSelectDate?: (date: string) => void;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21

## 📝작업 내용

> 달력의 날짜를 눌렀을 때, dayStatus와 isDone의 값에 따라 오른쪽에 Greeting/GoalList/RecordList 중 조건에 맞는 컴포넌트를 띄우는 기능을 추가하였습니다.
> API를 연결 및 Greeting/RecordList UI를 구현할 예정입니다.

### 스크린샷 (선택)
<img width="1892" height="895" alt="달력날짜선택_Greeting" src="https://github.com/user-attachments/assets/073bcd10-14a5-4139-b1fc-cfa854d00aa0" />
<img width="1884" height="897" alt="달력날짜선택_GoalList" src="https://github.com/user-attachments/assets/88b28ce0-9dbf-4618-9cfa-28fec1b08362" />
<img width="1889" height="895" alt="달력날짜선택_RecordList" src="https://github.com/user-attachments/assets/0fedf5ef-1bbc-4dff-b33a-9758d2dc1ab3" />




## 💬리뷰 요구사항(선택)

> 의견을 자유롭게 펼쳐주세요.