### PR TITLE
FEAT: todo 조회, 개별 세트 완료 API 연동

### DIFF
--- a/src/api/todo.ts
+++ b/src/api/todo.ts
@@ -1,0 +1,10 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+import { TodoResponse } from "@/types/todos";
+
+export async function getTodoByDateApi(date: string): Promise<TodoResponse> {
+  const res = await apiClient.get(`/exercises?date=${date}`);
+  if (!res.data) {
+    throw new Error("todo 조회 실패");
+  }
+  return res.data;
+}

--- a/src/api/todoComplete.ts
+++ b/src/api/todoComplete.ts
@@ -1,0 +1,5 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+
+export async function todoCompleteApi(id: number) {
+  return apiClient.patch(`/todos/complete/${id}`);
+}

--- a/src/components/todos/TodoItem.tsx
+++ b/src/components/todos/TodoItem.tsx
@@ -1,21 +1,27 @@
 "server-only";
 
 import TodoSetRow from "@/components/todos/TodoSetRow";
-import { Todo } from "@/types/todos";
+import { GroupedTodo } from "@/types/todos";
 
-export default function TodoItem({ exerciseName, sets, todoId }: Todo) {
+export default function TodoItem({
+  exerciseId,
+  exerciseName,
+  sets,
+}: GroupedTodo) {
   return (
-    <div className="w-141 min-h-3 flex flex-col bg-white p-4 py-5 border border-fitlog-beige rounded-[20px] mt-4 first:mt-0 ">
+    <div className="w-141 min-h-3 flex flex-col bg-white p-4 py-5 border border-fitlog-beige rounded-[20px] mt-4 first:mt-0">
       <p className="ml-2 mt-2 font-bold">{exerciseName}</p>
 
       <div className="mt-2 flex flex-col gap-4">
-        {sets.map((set, index) => (
+        {sets.map((set) => (
           <TodoSetRow
-            key={`${todoId}-${index}`}
-            setNumber={index + 1}
+            key={set.todoId}
+            todoId={set.todoId}
+            setsNumber={set.setsNumber}
+            repsTarget={set.repsTarget}
+            weight={set.weight}
+            restTime={set.restTime}
             isCompleted={set.isCompleted}
-            todoId={todoId}
-            setId={set.setId}
           />
         ))}
       </div>

--- a/src/components/todos/TodoSetRow.tsx
+++ b/src/components/todos/TodoSetRow.tsx
@@ -56,6 +56,8 @@ export default function TodoSetRow({
     setIsResting(true);
   };
 
+  const isRestDisabled = !isCompleted || isResting || restTime !== null;
+
   return (
     <div className="flex flex-row gap-3 justify-center items-center">
       <Checkbox
@@ -105,11 +107,11 @@ export default function TodoSetRow({
       초
       <ActionButton
         onClick={handleStartResting}
-        disabled={!isCompleted || isResting}
+        disabled={isRestDisabled}
         className={`flex items-center justify-center w-17 h-9 rounded-xl shadow-fitlog-btn-sm
           ${
-            isResting
-              ? "bg-fitlog-500 text-white hover:bg-fitlog-500 cursor-auto"
+            isResting || restTime !== null
+              ? "bg-fitlog-500 text-white hover:bg-fitlog-500 cursor-not-allowed"
               : "bg-white border border-fitlog-500/60 text-fitlog-500 hover:bg-fitlog-100"
           }
           ${!isCompleted ? "cursor-not-allowed hover:bg-white!" : ""}

--- a/src/components/todos/TodoSetRow.tsx
+++ b/src/components/todos/TodoSetRow.tsx
@@ -3,64 +3,91 @@
 import { ChevronRight } from "lucide-react";
 import ActionButton from "@/components/ui/ActionButton";
 import Checkbox from "@/components/ui/CheckBox";
-import Input from "@/components/ui/Input";
 import { useState } from "react";
 import { useAppDispatch } from "@/store/redux/hooks";
-import { todoSetCompleted } from "@/store/redux/features/todos/todoSlice";
-import { startRest } from "@/store/redux/features/todos/timerSlice";
-
-interface TodoSetRowProps {
-  todoId: number;
-  setId: number;
-  setNumber: number;
-  isCompleted: boolean;
-}
+import {
+  toggleTodoCompleted,
+  updateTodoCompleted,
+} from "@/store/redux/features/todos/todoSlice";
+import { useTodoComplete } from "@/lib/tanstack/mutation/todoComplete";
+import { TodoSetRowResponse } from "@/types/todos";
 
 export default function TodoSetRow({
-  setNumber,
-  isCompleted,
   todoId,
-  setId,
-}: TodoSetRowProps) {
+  setsNumber,
+  repsTarget,
+  weight,
+  restTime,
+  isCompleted,
+}: TodoSetRowResponse) {
   const [isResting, setIsResting] = useState<boolean>(false);
   const dispatch = useAppDispatch();
+  const { mutate: completeTodo, isPending } = useTodoComplete();
+
+  // 완료 토글
   const handleCompleted = () => {
-    dispatch(todoSetCompleted({ todoId, setId }));
+    if (isPending) return;
+
+    // 즉시 Redux 상태 업데이트 (Optimistic Update)
+    dispatch(toggleTodoCompleted(todoId));
+
+    // API 호출 (tanstack)
+    completeTodo(todoId, {
+      onSuccess: (response) => {
+        if (response?.data) {
+          dispatch(
+            updateTodoCompleted({
+              todoId: response.data.todoId,
+              isCompleted: response.data.isCompleted,
+            })
+          );
+        }
+      },
+      onError: (error) => {
+        console.error("세트 완료 실패:", error);
+        dispatch(toggleTodoCompleted(todoId));
+        alert("세트 완료에 실패했습니다. 다시 시도해주세요.");
+      },
+    });
   };
 
   const handleStartResting = () => {
-    dispatch(startRest(0));
+    // TODO: 타이머 시작 로직
     setIsResting(true);
   };
 
   return (
     <div className="flex flex-row gap-3 justify-center items-center">
-      <Checkbox checked={isCompleted} onChange={handleCompleted} />
-      <p className="font-bold w-12">Set {setNumber}</p>
+      <Checkbox
+        checked={isCompleted}
+        onChange={handleCompleted}
+        disabled={isPending}
+      />
+      <p className="font-bold w-12">Set {setsNumber}</p>
       <div
         className={`w-23 h-9 px-3 text-sm rounded-xl border shadow-fitlog-btn-sm
-    flex items-center justify-center
-    ${
-      isCompleted
-        ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
-        : "border-fitlog-beige text-fitlog-text"
-    }
-  `}
+          flex items-center justify-center
+          ${
+            isCompleted
+              ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
+              : "border-fitlog-beige text-fitlog-text"
+          }
+        `}
       >
-        10
+        {repsTarget}
       </div>
       회
       <div
         className={`w-23 h-9 px-3 text-sm rounded-xl border shadow-fitlog-btn-sm
-    flex items-center justify-center
-    ${
-      isCompleted
-        ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
-        : "border-fitlog-beige text-fitlog-text"
-    }
-  `}
+          flex items-center justify-center
+          ${
+            isCompleted
+              ? "border-fitlog-beige bg-[#EEEEEE] text-gray-400 cursor-auto"
+              : "border-fitlog-beige text-fitlog-text"
+          }
+        `}
       >
-        0
+        {weight}
       </div>
       kg
       <div
@@ -73,7 +100,7 @@ export default function TodoSetRow({
           }
         `}
       >
-        -
+        {restTime ?? "-"}
       </div>
       초
       <ActionButton
@@ -85,7 +112,7 @@ export default function TodoSetRow({
               ? "bg-fitlog-500 text-white hover:bg-fitlog-500 cursor-auto"
               : "bg-white border border-fitlog-500/60 text-fitlog-500 hover:bg-fitlog-100"
           }
-          ${!isCompleted ? "cursor-not-allowed  hover:bg-white! " : ""}
+          ${!isCompleted ? "cursor-not-allowed hover:bg-white!" : ""}
         `}
       >
         휴식

--- a/src/components/todos/TodosContainer.tsx
+++ b/src/components/todos/TodosContainer.tsx
@@ -1,82 +1,106 @@
 "use client";
 
 import TodoItem from "@/components/todos/TodoItem";
-import { setTodos } from "@/store/redux/features/todos/todoSlice";
+import { useTodosByDate } from "@/lib/tanstack/query/todos";
 import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
-import { useEffect } from "react";
-
-const mockData = [
-  {
-    todoId: 1,
-    exerciseName: "스쿼트",
-    sets: [
-      { setId: 1, isCompleted: true },
-      { setId: 2, isCompleted: false },
-      { setId: 3, isCompleted: false },
-    ],
-  },
-  {
-    todoId: 2,
-    exerciseName: "벤치프레스",
-    sets: [
-      { setId: 1, isCompleted: false },
-      { setId: 2, isCompleted: false },
-    ],
-  },
-  {
-    todoId: 3,
-    exerciseName: "스쿼트",
-    sets: [
-      { setId: 1, isCompleted: false },
-      { setId: 2, isCompleted: false },
-      { setId: 3, isCompleted: false },
-    ],
-  },
-  {
-    todoId: 4,
-    exerciseName: "벤치프레스",
-    sets: [
-      { setId: 1, isCompleted: false },
-      { setId: 2, isCompleted: false },
-    ],
-  },
-  {
-    todoId: 5,
-    exerciseName: "벤치프레스",
-    sets: [
-      { setId: 1, isCompleted: false },
-      { setId: 2, isCompleted: false },
-      { setId: 3, isCompleted: false },
-    ],
-  },
-  {
-    todoId: 6,
-    exerciseName: "스쿼트",
-    sets: [
-      { setId: 1, isCompleted: false },
-      { setId: 2, isCompleted: false },
-      { setId: 3, isCompleted: false },
-    ],
-  },
-];
+import { setTodosData } from "@/store/redux/features/todos/todoSlice";
+import { GroupedTodo } from "@/types/todos";
+import { useEffect, useMemo } from "react";
 
 export default function TodosContainer() {
   const dispatch = useAppDispatch();
-  const todos = useAppSelector((state) => state.todos.todos);
+  const todosData = useAppSelector((state) => state.todos.data);
+  const today = new Date().toISOString().split("T")[0];
+  const { data: apiData, isLoading, error } = useTodosByDate(today);
 
+  // API 데이터가 변경되면 Redux에 저장
   useEffect(() => {
-    dispatch(setTodos(mockData));
-  }, [dispatch]);
+    if (apiData) {
+      dispatch(setTodosData(apiData));
+    }
+  }, [apiData, dispatch]);
+
+  // Redux 상태를 운동별로 그룹화
+  const groupedTodos = useMemo(() => {
+    if (!todosData?.exercises) return [];
+
+    const grouped = todosData.exercises.reduce((acc, exercise) => {
+      const existing = acc.find(
+        (item) => item.exerciseId === exercise.exerciseId
+      );
+
+      const setInfo = {
+        todoId: exercise.todoId,
+        setsNumber: exercise.setsNumber,
+        repsTarget: exercise.repsTarget,
+        weight: exercise.weight,
+        restTime: exercise.restTime,
+        isCompleted: exercise.isCompleted,
+      };
+
+      if (existing) {
+        existing.sets.push(setInfo);
+      } else {
+        acc.push({
+          exerciseId: exercise.exerciseId,
+          exerciseName: exercise.exerciseName,
+          sets: [setInfo],
+        });
+      }
+
+      return acc;
+    }, [] as GroupedTodo[]);
+
+    // 각 운동의 세트를 번호순으로 정렬
+    grouped.forEach((todo) => {
+      todo.sets.sort((a, b) => a.setsNumber - b.setsNumber);
+    });
+
+    return grouped;
+  }, [todosData?.exercises]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col">
+        <p className="mt-5 mb-3 text-center text-lg font-semibold">운동 목표</p>
+        <div className="flex justify-center items-center min-h-40">
+          <p className="text-gray-500">로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col">
+        <p className="mt-5 mb-3 text-center text-lg font-semibold">운동 목표</p>
+        <div className="flex justify-center items-center min-h-40">
+          <p className="text-red-500">데이터를 불러오는데 실패했습니다.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!groupedTodos.length) {
+    return (
+      <div className="flex flex-col">
+        <p className="mt-5 mb-3 text-center text-lg font-semibold">운동 목표</p>
+        <div className="flex justify-center items-center min-h-40">
+          <p className="text-gray-500">오늘 계획된 운동이 없습니다.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col">
       <p className="mt-5 mb-3 text-center text-lg font-semibold">운동 목표</p>
 
       <div className="pb-4">
-        {todos.map((todo) => (
+        {groupedTodos.map((todo) => (
           <TodoItem
-            key={todo.todoId}
-            todoId={todo.todoId}
+            key={todo.exerciseId}
+            exerciseId={todo.exerciseId}
             exerciseName={todo.exerciseName}
             sets={todo.sets}
           />

--- a/src/lib/tanstack/mutation/todoComplete.ts
+++ b/src/lib/tanstack/mutation/todoComplete.ts
@@ -1,0 +1,8 @@
+import { todoCompleteApi } from "@/api/todoComplete";
+import { useMutation } from "@tanstack/react-query";
+
+export function useTodoComplete() {
+  return useMutation({
+    mutationFn: todoCompleteApi,
+  });
+}

--- a/src/lib/tanstack/query/todos.ts
+++ b/src/lib/tanstack/query/todos.ts
@@ -1,0 +1,11 @@
+import { getTodoByDateApi } from "@/api/todo";
+import { useQuery } from "@tanstack/react-query";
+
+export function useTodosByDate(date: string) {
+  return useQuery({
+    queryKey: ["todos", date],
+    queryFn: () => getTodoByDateApi(date),
+    staleTime: 1000 * 60 * 5, // 5분
+    gcTime: 1000 * 60 * 10,
+  });
+}

--- a/src/store/redux/features/todos/todoSlice.ts
+++ b/src/store/redux/features/todos/todoSlice.ts
@@ -1,36 +1,62 @@
-import { Todo, Todos } from "@/types/todos";
+import { TodoResponse } from "@/types/todos";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-const initialState: Todos = {
-  todos: [],
-};
-
-interface TodoSetCompletedPayload {
-  todoId: number;
-  setId: number;
+interface TodosState {
+  data: TodoResponse | null;
 }
+
+const initialState: TodosState = {
+  data: null,
+};
 
 const todosSlice = createSlice({
   name: "todos",
   initialState,
   reducers: {
-    todoSetCompleted(state, action: PayloadAction<TodoSetCompletedPayload>) {
-      const { todoId, setId } = action.payload;
-
-      const todo = state.todos.find((todo) => todo.todoId === todoId);
-      if (!todo) return;
-
-      const set = todo.sets.find((set) => set.setId === setId);
-      if (!set) return;
-
-      set.isCompleted = !set.isCompleted;
+    // API 데이터 전체 설정
+    setTodosData(state, action: PayloadAction<TodoResponse>) {
+      state.data = action.payload;
     },
 
-    setTodos(state, action: PayloadAction<Todo[]>) {
-      state.todos = action.payload;
+    // 개별 세트 완료 상태 토글
+    toggleTodoCompleted(state, action: PayloadAction<number>) {
+      const todoId = action.payload;
+
+      if (!state.data?.exercises) return;
+
+      const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
+      if (exercise) {
+        exercise.isCompleted = !exercise.isCompleted;
+      }
+    },
+
+    // 서버에서 완료 성공 후 상태 업데이트
+    updateTodoCompleted(
+      state,
+      action: PayloadAction<{ todoId: number; isCompleted: boolean }>
+    ) {
+      const { todoId, isCompleted } = action.payload;
+
+      if (!state.data?.exercises) return;
+
+      const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
+      if (exercise) {
+        exercise.isCompleted = isCompleted;
+      }
+    },
+
+    // 데이터 초기화
+    clearTodos(state) {
+      state.data = null;
     },
   },
 });
 
-export const { todoSetCompleted, setTodos } = todosSlice.actions;
+export const {
+  setTodosData,
+  toggleTodoCompleted,
+  updateTodoCompleted,
+  clearTodos,
+} = todosSlice.actions;
+
 export default todosSlice.reducer;

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -1,14 +1,40 @@
-export interface Set {
-  setId: number;
+// 개별 row 타입
+export interface TodoSetRowResponse {
+  todoId: number;
+  setsNumber: number;
+  repsTarget: number;
+  weight: number;
+  restTime: number | null;
   isCompleted: boolean;
 }
 
-export interface Todo {
-  todoId: number;
+// /exercises의 exercises 응답값 타입
+export interface TodoExercise extends TodoSetRowResponse {
+  exerciseId: number;
   exerciseName: string;
-  sets: Set[];
+  caloriesPerRep: number | null;
+  burnedCalories: number | null;
 }
 
-export interface Todos {
-  todos: Todo[];
+// /exercises 응답값 타입
+export interface TodoResponse {
+  date: string;
+  isDone: boolean;
+  exercises: TodoExercise[];
+  totalCalories: number;
+  message: string;
+}
+
+// 컴포넌트에서 사용할 그룹화된 타입 -> 렌더링용
+export interface GroupedTodo {
+  exerciseId: number;
+  exerciseName: string;
+  sets: {
+    todoId: number;
+    setsNumber: number;
+    repsTarget: number;
+    weight: number;
+    restTime: number | null;
+    isCompleted: boolean;
+  }[];
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #27 

## 📝작업 내용

> - 오늘 날짜에 해당하는 todo list (/exercises)를 조회하는 API를 연동했습니다.
> - 개별 세트 완료 API (/todos/complete)를 연동했습니다.
> - `restTime !== null` 이면 휴식을 취했단 의미이므로 휴식 버튼을 비활성화 처리했습니다 (동영상 참고)
> - 개별 세트 완료는 redux로 상태관리를 진행했습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/8131e0d9-446d-47d8-95e3-4fdb06583ccd

## 💬리뷰 요구사항(선택)

> 아직 휴식 관련 API는 연동하지 않았으니, 고려해서 봐주시면 좋겠습니다.
> 큰 문제가 없다면 GET /exercises 요청은 아래 `/api/todo.ts`, `/lib/tanstack/query/todos.ts`를 사용하면 될 것 같습니다.
