### PR TITLE
FEAT: 메인화면 서버연동 - 오른쪽 화면 분기

### DIFF
--- a/src/api/exerciseRecord.ts
+++ b/src/api/exerciseRecord.ts
@@ -1,0 +1,20 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+import { ExerciseResponse } from "@/types/exercise";
+
+/**
+ * 특정 날짜의 운동 계획 / 기록 조회
+ * GET /exercises?date=YYYY-MM-DD
+ */
+export async function getExercisesByDate(
+  date: string
+): Promise<ExerciseResponse> {
+  const res = await apiClient.get<ExerciseResponse>("/exercises", {
+    params: { date },
+  });
+
+  if (!res.data) {
+    throw new Error("운동 조회 실패");
+  }
+
+  return res.data;
+}

--- a/src/components/main-right/GoalList.tsx
+++ b/src/components/main-right/GoalList.tsx
@@ -1,136 +1,50 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React from "react";
 import GoalHeader from "@/components/main-right/GoalHeader";
 import SetList from "@/components/main-right/SetList";
 import ExercisesDropdownButton from "@/components/main-right/ExercisesDropdownButton";
 import { GoalType, SetUpdatePayload } from "@/types/todoMain";
 
-const mockDataGoal: GoalType[] = [
-  {
-    id: 1, // 운동 항목 ID
-    exercise: "벤치프레스", // 운동 종목
-    sets: [
-      {
-        id: 1, // 세트 ID
-        setsNumber: 1, // 세트 번호
-        repsTarget: "",
-        weight: "",
-      },
-    ],
-  },
+interface GoalListProps {
+  goals: GoalType[];
+}
 
-  {
-    id: 2,
-    exercise: "스쿼트",
-    sets: [
-      {
-        id: 1,
-        setsNumber: 1,
-        repsTarget: "",
-        weight: "",
-      },
-    ],
-  },
-];
-
-export default function GoalList() {
-  const [goals, setGoals] = useState<GoalType[]>(mockDataGoal);
-  const [completed, setCompleted] = useState(false);
-  const idRef = useRef(3);
-  const setIdRef = useRef(1);
+export default function GoalList({ goals }: GoalListProps) {
+  const completed = false;
 
   const onToggleCompleted = () => {
-    setCompleted(!completed);
+    // 👉 다음 단계에서 mutation으로 대체될 예정
   };
 
   const onCreateGoal = (exerciseName: string) => {
-    const newGoal: GoalType = {
-      id: idRef.current++,
-      exercise: exerciseName,
-      sets: [
-        {
-          id: setIdRef.current++,
-          setsNumber: 1,
-          repsTarget: "",
-          weight: "",
-        },
-      ],
-    };
-
-    setGoals([...goals, newGoal]);
+    // 👉 다음 단계: 운동 항목 추가 API
   };
 
   const onCreateSet = (goalId: number) => {
-    setGoals((prev) =>
-      prev.map((goal) =>
-        goal.id === goalId
-          ? {
-              ...goal,
-              sets: [
-                ...goal.sets,
-                {
-                  id: setIdRef.current++,
-                  setsNumber: goal.sets.length + 1,
-                  repsTarget: "",
-                  weight: "",
-                },
-              ],
-            }
-          : goal
-      )
-    );
+    // 👉 다음 단계
   };
 
   const onRemoveGoal = (goalId: number) => {
-    setGoals((prev) => prev.filter((goal) => goal.id !== goalId));
+    // 👉 다음 단계
   };
 
   const onRemoveSet = (goalId: number, setId: number) => {
-    setGoals((prev) =>
-      prev.flatMap((goal) => {
-        if (goal.id !== goalId) return goal;
-
-        // 세트가 1개뿐이면 → 운동(goal) 자체 삭제
-        if (goal.sets.length === 1) {
-          return [];
-        }
-
-        // 세트가 여러 개면 → 해당 세트만 삭제 + 번호 재정렬
-        const newSets = goal.sets
-          .filter((set) => set.id !== setId)
-          .map((set, index) => ({
-            ...set,
-            setsNumber: index + 1,
-          }));
-
-        return {
-          ...goal,
-          sets: newSets,
-        };
-      })
-    );
+    // 👉 다음 단계
   };
 
-  const onUpdateSet = (goalId: number, setId: number, newValues: SetUpdatePayload) => {
-    setGoals((prev) =>
-      prev.map((goal) =>
-        goal.id === goalId
-          ? {
-              ...goal,
-              sets: goal.sets.map((set) => (set.id === setId ? { ...set, ...newValues } : set)),
-            }
-          : goal
-      )
-    );
+  const onUpdateSet = (
+    goalId: number,
+    setId: number,
+    newValues: SetUpdatePayload
+  ) => {
+    // 👉 다음 단계
   };
 
   return (
     <div className="w-full flex flex-col gap-6">
-      {/* 날짜, 텍스트, 운동 시작 버튼 렌더링 */}
       <GoalHeader completed={completed} />
 
-      {/* SetList 여러개 렌더링 */}
       {goals.map((goal) => (
         <SetList
           key={goal.id}
@@ -143,7 +57,6 @@ export default function GoalList() {
         />
       ))}
 
-      {/* 버튼 렌더링 */}
       <ExercisesDropdownButton
         completed={completed}
         onToggleCompleted={onToggleCompleted}

--- a/src/components/main-right/RecordList.tsx
+++ b/src/components/main-right/RecordList.tsx
@@ -1,9 +1,34 @@
-import React from 'react';
+"use client";
 
-export default function RecordList() {
-    return (
-        <div>
-            RecordList
+import { ExerciseItem } from "@/types/exercise";
+
+interface RecordListProps {
+  exercises: ExerciseItem[];
+  totalCalories: number;
+}
+
+export default function RecordList({
+  exercises,
+  totalCalories,
+}: RecordListProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-lg font-bold">
+        총 소모 칼로리: {totalCalories} kcal
+      </h2>
+
+      {exercises.map((item) => (
+        <div key={item.todoId} className="rounded-lg border p-4">
+          <p className="font-semibold">{item.exerciseName}</p>
+          <p>
+            {item.setsNumber}세트 · {item.repsTarget}회 ·{" "}
+            {item.weight ?? 0}kg
+          </p>
+          <p className="text-sm text-gray-500">
+            소모: {item.burnedCalories ?? 0} kcal
+          </p>
         </div>
-    );
-};
+      ))}
+    </div>
+  );
+}

--- a/src/components/main-right/SetList.tsx
+++ b/src/components/main-right/SetList.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React from "react";
 import ActionButton from "@/components/ui/ActionButton";
 import { Plus } from "lucide-react";

--- a/src/components/main/MainClient.tsx
+++ b/src/components/main/MainClient.tsx
@@ -27,29 +27,25 @@ export default function MainClient() {
       {/* RIGHT */}
       <section className="flex min-h-0 flex-col">
         <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
-          {!data && !isLoading && !error && <Greeting username="준형" />}
+          {/* 날짜 선택 안 했을 때만 */}
+          {!selectedDate && !isLoading && !error && <Greeting username="준형" />}
 
-          {isLoading && (
-            <p className="mt-10 text-center text-gray-400">
-              운동 정보를 불러오는 중...
-            </p>
+          {/* 날짜 선택 후 로딩 */}
+          {selectedDate && isLoading && (
+            <p className="mt-10 text-center text-gray-400">운동 정보를 불러오는 중...</p>
           )}
 
-          {error && (
-            <p className="mt-10 text-center text-red-400">
-              운동 정보를 불러오지 못했어요.
-            </p>
+          {/* 날짜 선택 후 에러 */}
+          {selectedDate && error && (
+            <p className="mt-10 text-center text-red-400">운동 정보를 불러오지 못했어요.</p>
           )}
 
-          {data && !hasTodos && <Greeting username="준형" />}
+          {/* 날짜 선택 + 운동 미완료 (목표가 없든 있든) */}
+          {selectedDate && data && !data.isDone && <GoalList />}
 
-          {data && hasTodos && !isDone && <GoalList />}
-
-          {data && hasTodos && isDone && (
-            <RecordList
-              exercises={data.exercises}
-              totalCalories={data.totalCalories}
-            />
+          {/* 날짜 선택 + 운동 완료 */}
+          {selectedDate && data && data.isDone && (
+            <RecordList exercises={data.exercises} totalCalories={data.totalCalories} />
           )}
         </div>
       </section>

--- a/src/components/main/MainClient.tsx
+++ b/src/components/main/MainClient.tsx
@@ -6,42 +6,51 @@ import FillLevel from "@/components/main-left/FillLevel";
 import GoalList from "@/components/main-right/GoalList";
 import Greeting from "@/components/main-right/Greeting";
 import RecordList from "@/components/main-right/RecordList";
+import { useExercisesByDate } from "@/lib/tanstack/query/exerciseRecord";
 
 export default function MainClient() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const [dayStatus, setDayStatus] = useState<{
-    hasTodos: boolean;
-    isDone: boolean;
-  } | null>(null);
 
-  const handleSelectDate = (date: string) => {
-    setSelectedDate(date);
+  const { data, isLoading, error } = useExercisesByDate(selectedDate);
 
-    // mock
-    if (date === "2025-12-15") {
-      setDayStatus({ hasTodos: true, isDone: false });
-    } else if (date === "2025-12-16") {
-      setDayStatus({ hasTodos: true, isDone: true });
-    } else {
-      setDayStatus({ hasTodos: false, isDone: false });
-    }
-  };
+  const hasTodos = data && data.exercises.length > 0;
+  const isDone = data?.isDone;
 
   return (
-    <div className="md:h-[calc(100vh-72px) grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
+    <div className="md:h-[calc(100vh-72px)] grid w-full max-w-6xl grid-cols-1 gap-16 py-24 md:grid-cols-2">
       {/* LEFT */}
       <section className="mt-[72px] flex flex-col items-center">
-        <Calendar className="w-full" onSelectDate={handleSelectDate} />
+        <Calendar className="w-full" onSelectDate={setSelectedDate} />
         <FillLevel className="w-full pt-6" />
       </section>
 
       {/* RIGHT */}
       <section className="flex min-h-0 flex-col">
         <div className="min-h-0 w-full overflow-y-auto md:h-full md:flex-1">
-          {!dayStatus && <Greeting username="준형" />}
-          {dayStatus && !dayStatus.hasTodos && <Greeting username="준형" />}
-          {dayStatus && dayStatus.hasTodos && !dayStatus.isDone && <GoalList />}
-          {dayStatus && dayStatus.hasTodos && dayStatus.isDone && <RecordList />}
+          {!data && !isLoading && !error && <Greeting username="준형" />}
+
+          {isLoading && (
+            <p className="mt-10 text-center text-gray-400">
+              운동 정보를 불러오는 중...
+            </p>
+          )}
+
+          {error && (
+            <p className="mt-10 text-center text-red-400">
+              운동 정보를 불러오지 못했어요.
+            </p>
+          )}
+
+          {data && !hasTodos && <Greeting username="준형" />}
+
+          {data && hasTodos && !isDone && <GoalList />}
+
+          {data && hasTodos && isDone && (
+            <RecordList
+              exercises={data.exercises}
+              totalCalories={data.totalCalories}
+            />
+          )}
         </div>
       </section>
     </div>

--- a/src/lib/tanstack/query/exerciseRecord.ts
+++ b/src/lib/tanstack/query/exerciseRecord.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getExercisesByDate } from "@/api/exerciseRecord";
+import { ExerciseResponse } from "@/types/exercise";
+
+export function useExercisesByDate(date: string | null) {
+  return useQuery<ExerciseResponse>({
+    queryKey: ["exercises", date],
+    queryFn: () => getExercisesByDate(date as string),
+    enabled: !!date, // 날짜 선택 전에는 요청 안 함
+  });
+}

--- a/src/types/exercise.ts
+++ b/src/types/exercise.ts
@@ -1,0 +1,20 @@
+export interface ExerciseItem {
+  todoId: number;
+  exerciseId: number;
+  exerciseName: string;
+  setsNumber: number;
+  repsTarget: number;
+  weight: number | null;
+  restTime: number | null;
+  isCompleted: boolean;
+  caloriesPerRep?: number;
+  burnedCalories?: number;
+}
+
+export interface ExerciseResponse {
+  date: string;
+  isDone: boolean;
+  exercises: ExerciseItem[];
+  totalCalories: number;
+  message: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28

## 📝작업 내용

> 달력의 날짜를 클릭했을 때, 서버의 데이터에 따라 오른쪽 화면이 분기되도록 연동하였습니다.
> 1. 운동 항목 리스트 API 연동
> 2. 운동 목록 조회 API 연동
> 3. 운동시작 버튼 누를 시 컨텍스트 유지한 채로 세부화면으로 이동
> 3가지를 마치면 세부화면 플로우와 연결될 것 같습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
