### PR TITLE
FEAT: Todo 휴식 시간 API 연동

### DIFF
--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -1,0 +1,9 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+
+export async function patchRestTimeApi(todoId: number, restTime: number) {
+  return apiClient.patch(`/todos/rest/${todoId}`, { restTime });
+}
+
+export async function deleteRestTimeApi(todoId: number) {
+  return apiClient.delete(`/todos/rest/reset/${todoId}`);
+}

--- a/src/components/todos/Timer.tsx
+++ b/src/components/todos/Timer.tsx
@@ -5,24 +5,45 @@ import ActionButton from "@/components/ui/ActionButton";
 import { useState, useRef, useEffect } from "react";
 import FinishButton from "@/components/todos/FinishButton";
 import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
-import { stopRest } from "@/store/redux/features/todos/timerSlice";
+import { clearTimer, stopRest } from "@/store/redux/features/todos/timerSlice";
+import {
+  useRestTimeRecord,
+  useRestTimeReset,
+} from "@/lib/tanstack/mutation/rest";
+import {
+  resetRestTime,
+  updateRestTime,
+} from "@/store/redux/features/todos/todoSlice";
 
-export default function Timer() {
+interface TimerProps {
+  currentTodoId?: number;
+}
+
+export default function Timer({ currentTodoId }: TimerProps = {}) {
   const [time, setTime] = useState<number>(0);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const [records, setRecords] = useState<number[]>([]);
 
   const dispatch = useAppDispatch();
-  const { isActive, duration } = useAppSelector((state) => state.timer);
+  const { isActive, duration, todoId } = useAppSelector((state) => state.timer);
+
+  // 이 타이머가 활성화되어야 하는지 확인
+  const isThisTimerActive =
+    isActive && (!currentTodoId || todoId === currentTodoId);
+
+  const { mutate: recordRestTime, isPending } = useRestTimeRecord();
+  const { mutate: resetRestTimeApi, isPending: isResetting } =
+    useRestTimeReset();
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isThisTimerActive) return;
     setTime(duration);
     setIsRunning(false);
-  }, [isActive, duration]);
+  }, [isThisTimerActive, duration]);
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
+  // 타이머 시간
   const formatTime = (milliseconds: number) => {
     const totalSeconds = Math.floor(milliseconds / 1000);
     const minutes = Math.floor(totalSeconds / 60);
@@ -53,19 +74,51 @@ export default function Timer() {
   };
 
   const handleRecord = () => {
-    if (time > 0) {
+    if (time > 0 && todoId) {
       const seconds = Math.floor(time / 1000);
-      setRecords((prev) => [...prev, seconds]);
-      console.log(records);
-      setTime(0);
-      setIsRunning(false);
+
+      recordRestTime(
+        { todoId, restTime: seconds },
+        {
+          onSuccess: () => {
+            setRecords((prev) => [...prev, seconds]);
+            dispatch(
+              updateRestTime({
+                todoId,
+                restTime: seconds,
+              })
+            );
+            setTime(0);
+            setIsRunning(false);
+            dispatch(stopRest());
+          },
+          onError: (error) => {
+            console.error("휴식 시간 기록 실패:", error);
+          },
+        }
+      );
     }
-    dispatch(stopRest());
   };
 
   const handleReset = () => {
-    setIsRunning(false);
-    setTime(0);
+    if (todoId) {
+      resetRestTimeApi(todoId, {
+        onSuccess: () => {
+          // Redux에서 restTime 초기화 (null)
+          dispatch(resetRestTime(todoId));
+          setIsRunning(false);
+          setTime(0);
+          dispatch(clearTimer()); // todoId도 null로 초기화
+        },
+        onError: (error) => {
+          console.error("휴식 시간 초기화 실패:", error);
+        },
+      });
+    } else {
+      // todoId가 없으면 그냥 로컬 타이머만 초기화
+      setIsRunning(false);
+      setTime(0);
+    }
   };
 
   return (
@@ -82,7 +135,7 @@ export default function Timer() {
           <div className="grid grid-cols-3 gap-3">
             <ActionButton
               onClick={handleRunning}
-              disabled={!isActive}
+              disabled={!isThisTimerActive}
               className="flex w-full items-center justify-center py-2.5 shadow-fitlog-btn-sm disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
             >
               {!isRunning ? (
@@ -99,19 +152,19 @@ export default function Timer() {
             </ActionButton>
             <ActionButton
               onClick={handleRecord}
-              disabled={!isActive}
+              disabled={!isThisTimerActive || isPending}
               className="flex w-full items-center justify-center py-2.5 bg-fitlog-400 shadow-fitlog-btn-sm hover:bg-[#CC595F] disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
             >
               <Square className="mr-2 h-4 w-4" />
-              기록
+              {isPending ? "기록 중..." : "기록"}
             </ActionButton>
             <ActionButton
               onClick={handleReset}
-              // disabled={!isActive}
+              disabled={isResetting}
               className="flex w-full items-center justify-center py-2.5 bg-white border border-fitlog-beige text-fitlog-text shadow-fitlog-btn-sm hover:bg-[#F1F1F1] disabled:bg-fitlog-disabled disabled:cursor-not-allowed disabled:text-white"
             >
               <RotateCcw className="mr-2 h-4 w-4" />
-              초기화
+              {isResetting ? "초기화 중..." : "초기화"}
             </ActionButton>
           </div>
         </div>

--- a/src/lib/tanstack/mutation/rest.ts
+++ b/src/lib/tanstack/mutation/rest.ts
@@ -1,0 +1,16 @@
+import { deleteRestTimeApi, patchRestTimeApi } from "@/api/rest";
+import { RestTimeParams } from "@/types/timer";
+import { useMutation } from "@tanstack/react-query";
+
+export function useRestTimeRecord() {
+  return useMutation({
+    mutationFn: ({ todoId, restTime }: RestTimeParams) =>
+      patchRestTimeApi(todoId, restTime),
+  });
+}
+
+export function useRestTimeReset() {
+  return useMutation({
+    mutationFn: (todoId: number) => deleteRestTimeApi(todoId),
+  });
+}

--- a/src/store/redux/features/todos/timerSlice.ts
+++ b/src/store/redux/features/todos/timerSlice.ts
@@ -1,25 +1,54 @@
 import { Timer } from "@/types/timer";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+// sessionStorage에서 todoId 복원
+const getInitialTodoId = (): number | null => {
+  if (typeof window === "undefined") return null;
+  const saved = sessionStorage.getItem("lastTodoId");
+  return saved ? parseInt(saved, 10) : null;
+};
+
 const initialState: Timer = {
   isActive: false,
   duration: 0,
+  todoId: getInitialTodoId(),
 };
 
 const timerSlice = createSlice({
   name: "timer",
   initialState,
   reducers: {
-    startRest(state, action: PayloadAction<number>) {
+    // 휴식 시작
+    startRest(
+      state,
+      action: PayloadAction<{ duration: number; todoId: number }>
+    ) {
       state.isActive = true;
-      state.duration = action.payload;
+      state.duration = action.payload.duration;
+      state.todoId = action.payload.todoId;
+
+      // sessionStorage에 마지막으로 선택된 todoId 저장
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem("lastTodoId", action.payload.todoId.toString());
+      }
     },
+    // 휴식 스탑
     stopRest(state) {
       state.isActive = false;
       state.duration = 0;
     },
+    // 타이머 초기화
+    clearTimer(state) {
+      state.isActive = false;
+      state.duration = 0;
+      state.todoId = null;
+      // sessionStorage에서 제거
+      if (typeof window !== "undefined") {
+        sessionStorage.removeItem("lastTodoId");
+      }
+    },
   },
 });
 
-export const { startRest, stopRest } = timerSlice.actions;
+export const { startRest, stopRest, clearTimer } = timerSlice.actions;
 export default timerSlice.reducer;

--- a/src/store/redux/features/todos/todoSlice.ts
+++ b/src/store/redux/features/todos/todoSlice.ts
@@ -3,17 +3,19 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface TodosState {
   data: TodoResponse | null;
+  lastCompletedTodoId: number | null; // 마지막으로 선택(완료 체크)한 todoId
 }
 
 const initialState: TodosState = {
   data: null,
+  lastCompletedTodoId: null,
 };
 
 const todosSlice = createSlice({
   name: "todos",
   initialState,
   reducers: {
-    // API 데이터 전체 설정
+    // 투두 조회
     setTodosData(state, action: PayloadAction<TodoResponse>) {
       state.data = action.payload;
     },
@@ -27,6 +29,10 @@ const todosSlice = createSlice({
       const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
       if (exercise) {
         exercise.isCompleted = !exercise.isCompleted;
+
+        if (exercise.isCompleted) {
+          state.lastCompletedTodoId = todoId;
+        }
       }
     },
 
@@ -42,12 +48,43 @@ const todosSlice = createSlice({
       const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
       if (exercise) {
         exercise.isCompleted = isCompleted;
+
+        if (isCompleted) {
+          state.lastCompletedTodoId = todoId;
+        }
+      }
+    },
+
+    // 휴식 시간 업데이트
+    updateRestTime(
+      state,
+      action: PayloadAction<{ todoId: number; restTime: number }>
+    ) {
+      const { todoId, restTime } = action.payload;
+
+      if (!state.data?.exercises) return;
+
+      const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
+      if (exercise) {
+        exercise.restTime = restTime;
+      }
+    },
+    // 휴식 시간 초기화
+    resetRestTime(state, action: PayloadAction<number>) {
+      const todoId = action.payload;
+
+      if (!state.data?.exercises) return;
+
+      const exercise = state.data.exercises.find((ex) => ex.todoId === todoId);
+      if (exercise) {
+        exercise.restTime = null;
       }
     },
 
     // 데이터 초기화
     clearTodos(state) {
       state.data = null;
+      state.lastCompletedTodoId = null;
     },
   },
 });
@@ -56,6 +93,8 @@ export const {
   setTodosData,
   toggleTodoCompleted,
   updateTodoCompleted,
+  updateRestTime,
+  resetRestTime,
   clearTodos,
 } = todosSlice.actions;
 

--- a/src/types/timer.ts
+++ b/src/types/timer.ts
@@ -1,4 +1,10 @@
 export interface Timer {
   isActive: boolean;
   duration: number; // 초
+  todoId: number | null;
+}
+
+export interface RestTimeParams {
+  todoId: number;
+  restTime: number;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #30 

## 📝작업 내용

> - 휴식시간 기록, 초기화 API 연동했습니다. (동영상 참고)
>   - 사용자는 운동 체크 완료 해야 '휴식' 버튼을 클릭할 수 있습니다.
>   - '휴식' 버튼을 누르면 타이머가 활성화되어서 시작,기록,초기화를 할 수 있습니다.
>       - '기록'을 누르면 해당 시간이 좌측 rest time에 기록이 됩니다. ('휴식' 버튼 비활성화)
>       - '기록'을 누르지 않은 상태에서 '초기화'를 누르면 단순히 시간만 0초가 됩니다.
>       - '기록'을 누른 상태에서 '초기화'를 누르면 기록된 시간이 0초가 되어 '휴식' 버튼이 활성화됩니다.
>       - 이 과정에서 사용자는 바로 직전에 선택했던 todoId에 해당하는 것만 휴식 시간만 관리할 수 있습니다. (만약 한참 전 todoId를 수정하고자 하면, 완료 처리를 해제하고 다시 지정이 가능합니다..)
>   - `완료` 를 해제하면, 기존에 저장되었던 rest time === Null 이 됩니다.
> - 바로 직전에 선택했던 todoId는 세션스토리지에서 관리하여 새로고침해도 todoId를 기억할 수 있도록 구현했습니다.

### 스크린샷 (선택)


https://github.com/user-attachments/assets/891a2775-29fd-4e4f-ab44-bb8cb75890e1



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
