### PR TITLE
FEAT: todos 운동 완료 API 연동 및 운동 시작 상태에 따른 /todos 도메인 접근 금지 구현, 404 에러 페이지

### DIFF
--- a/src/api/todoDone.ts
+++ b/src/api/todoDone.ts
@@ -1,0 +1,5 @@
+import { apiClient } from "@/lib/interceptor/clientInterceptor";
+
+export async function todosDoneApi(date: string) {
+  return apiClient.patch(`/todos/done/${date}`);
+}

--- a/src/app/api/todos/end/route.ts
+++ b/src/app/api/todos/end/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set("canEnterTodos", "", { maxAge: 0, path: "/" });
+  return res;
+}

--- a/src/app/api/todos/start/route.ts
+++ b/src/app/api/todos/start/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set("canEnterTodos", "true", {
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+  });
+  return res;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import ActionButton from "@/components/ui/ActionButton";
+
+export default function NotFound() {
+  return (
+    <main className="bg-secondary-100 flex min-h-dvh items-center justify-center px-6">
+      <div className="shadow-fitlog-form border-fitlog-beige w-full max-w-md rounded-2xl border bg-white p-8 text-center">
+        <div className="bg-fitlog-50 text-fitlog-600 mx-auto mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold">
+          <span className="bg-fitlog-500 inline-block h-2 w-2 rounded-full" />
+          404 Not Found
+        </div>
+
+        <h1 className="text-2xl font-bold text-gray-900">페이지를 찾을 수 없어요</h1>
+        <p className="mt-2 text-sm leading-relaxed text-gray-500">
+          주소가 잘못됐거나, 페이지가 이동/삭제됐을 수 있어요.
+          <br />
+          아래 버튼으로 메인으로 돌아가 주세요.
+        </p>
+
+        <div className="mt-4 flex justify-center">
+          <ActionButton className="shadow-fitlog-btn-sm rounded-xl px-6 py-2">
+            <Link href="/">메인으로 가기</Link>
+          </ActionButton>
+        </div>
+
+        <div className="mt-5 text-xs text-gray-400">
+          계속 문제가 있으면 새로고침 후 다시 시도해 주세요.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -5,6 +5,8 @@ import TodosContainer from "@/components/todos/TodosContainer";
 import BackToMainButton from "@/components/ui/BackToMainButton";
 
 export default function TodosPage() {
+  const today = new Date().toISOString().split("T")[0];
+
   return (
     <div className="flex h-screen flex-col px-28">
       <BackToMainButton />
@@ -15,7 +17,7 @@ export default function TodosPage() {
         </section>
 
         <section className="flex items-center justify-center">
-          <Timer />
+          <Timer date={today} />
         </section>
       </div>
     </div>

--- a/src/components/main-right/GoalHeader.tsx
+++ b/src/components/main-right/GoalHeader.tsx
@@ -4,7 +4,8 @@ import { useRouter } from "next/navigation";
 export default function GoalHeader({ completed }: { completed: boolean }) {
   const router = useRouter();
 
-  const handleStartWorkout = () => {
+  const handleStartWorkout = async () => {
+    await fetch("/api/todos/start", { method: "POST" });
     router.push("/todos");
   };
 
@@ -20,7 +21,14 @@ export default function GoalHeader({ completed }: { completed: boolean }) {
         <h1 className="text-xl font-semibold"> 운동 목표</h1>
       </div>
 
-      {completed && <ActionButton onClick={handleStartWorkout} className="p-3 color-white text-md">운동 시작</ActionButton>}
+      {completed && (
+        <ActionButton
+          onClick={handleStartWorkout}
+          className="p-3 color-white text-md"
+        >
+          운동 시작
+        </ActionButton>
+      )}
     </div>
   );
 }

--- a/src/components/todos/FinishButton.tsx
+++ b/src/components/todos/FinishButton.tsx
@@ -1,24 +1,27 @@
 "use client";
 
 import ActionButton from "@/components/ui/ActionButton";
+import { useTodosDone } from "@/lib/tanstack/mutation/todosDone";
 import { useRouter } from "next/navigation";
 
-export default function FinishButton() {
+export default function FinishButton({ date }: { date: string }) {
   const router = useRouter();
+  const { mutate: todosDone, isPending } = useTodosDone();
   const handleIsDone = () => {
-    // 1. 서버에 오늘 운동 완료 처리
-    // await fetch("/api/todos/done", {
-    //   method: "PATCH",
-    //   credentials: "include",
-    // });
-
-    // 2. 메인으로 이동
-    router.push("/");
+    todosDone(date, {
+      onSuccess: async () => {
+        await fetch("/api/todos/end", { method: "POST" });
+        router.push("/");
+      },
+      onError: (error) => {
+        console.log("운동 완료 실패:", error);
+      },
+    });
   };
 
   return (
     <ActionButton onClick={handleIsDone} className="w-full py-3.5 mt-8">
-      운동 완료
+      {isPending ? "운동 완료 중..." : "운동 완료"}
     </ActionButton>
   );
 }

--- a/src/components/todos/Timer.tsx
+++ b/src/components/todos/Timer.tsx
@@ -7,7 +7,12 @@ import FinishButton from "@/components/todos/FinishButton";
 import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
 import { stopRest } from "@/store/redux/features/todos/timerSlice";
 
-export default function Timer() {
+interface TimerProps {
+  currentTodoId?: number;
+  date: string;
+}
+
+export default function Timer({ currentTodoId, date }: TimerProps) {
   const [time, setTime] = useState<number>(0);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const [records, setRecords] = useState<number[]>([]);
@@ -116,7 +121,7 @@ export default function Timer() {
           </div>
         </div>
       </div>
-      <FinishButton />
+      <FinishButton date={date} />
     </div>
   );
 }

--- a/src/components/todos/Timer.tsx
+++ b/src/components/todos/Timer.tsx
@@ -8,11 +8,10 @@ import { useAppDispatch, useAppSelector } from "@/store/redux/hooks";
 import { stopRest } from "@/store/redux/features/todos/timerSlice";
 
 interface TimerProps {
-  currentTodoId?: number;
   date: string;
 }
 
-export default function Timer({ currentTodoId, date }: TimerProps) {
+export default function Timer({ date }: TimerProps) {
   const [time, setTime] = useState<number>(0);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const [records, setRecords] = useState<number[]>([]);

--- a/src/lib/tanstack/mutation/todosDone.ts
+++ b/src/lib/tanstack/mutation/todosDone.ts
@@ -1,0 +1,8 @@
+import { todosDoneApi } from "@/api/todoDone";
+import { useMutation } from "@tanstack/react-query";
+
+export function useTodosDone() {
+  return useMutation({
+    mutationFn: (date: string) => todosDoneApi(date),
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,7 +19,16 @@ export function proxy(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // refresh token 존재 여부만 확인
+  // todos 진입 가드
+  if (pathname.startsWith("/todos")) {
+    const canEnterTodos = req.cookies.get("canEnterTodos")?.value;
+
+    if (!canEnterTodos) {
+      return NextResponse.redirect(new URL("/", req.url));
+    }
+  }
+
+  // 인증 가드
   const refreshToken = req.cookies.get("refreshToken");
 
   if (!refreshToken) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #34 

## 📝작업 내용
- 하루 운동 완료 API 구현

- 기존에는 /todos 도메인에 운동 시작 여부에 관계없이 항상 접근이 가능했지만,  next 서버 api와 proxy (middleware)를 사용해서 ‘운동 시작’ 상태여야만 /todos 도메인에 접근이 가능하도록 구현했습니다
- 운동 시작 상태는 쿠키로 관리하였고, 운동 완료 시 쿠키에 상태가 제거되며, 이렇게 되면 /todos에 접근이 불가합니다.

(동영상 속 현재 ‘운동 시작’ 버튼은 테스트를 위해 임시로 해둔 거라 이렇게 구동된다면 된다만 인지하면 될 것 같습니다.)

```
next 서버 api를 만든 이유: DB에서 따로 관리하는 파일이 없고, 단순 쿠키 관리이기 때문
```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/06e2d4e0-c3cc-45de-a14c-e97f604da99e

- 404 에러 페이지
<img width="1855" height="930" alt="image" src="https://github.com/user-attachments/assets/cd5384f1-248e-4fd2-915a-dde053f63b8b" />


## 💬리뷰 요구사항(선택)

