### PR TITLE
FIX: 시차로 인해, 세부화면에서 전날의 운동항목이 렌더링되는 문제 수정

### DIFF
--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -5,7 +5,8 @@ import TodosContainer from "@/components/todos/TodosContainer";
 import BackToMainButton from "@/components/ui/BackToMainButton";
 
 export default function TodosPage() {
-  const today = new Date().toISOString().split("T")[0];
+  // const today = new Date().toISOString().split("T")[0];
+  const today = new Date().toLocaleDateString("en-CA");
 
   return (
     <div className="flex h-screen flex-col px-28">
@@ -13,7 +14,7 @@ export default function TodosPage() {
 
       <div className="grid w-full grid-cols-1 gap-16 px-32 pt-40 lg:grid-cols-2">
         <section className="flex justify-center">
-          <TodosContainer />
+          <TodosContainer date={today} />
         </section>
 
         <section className="flex items-center justify-center">

--- a/src/components/todos/TodosContainer.tsx
+++ b/src/components/todos/TodosContainer.tsx
@@ -7,11 +7,14 @@ import { setTodosData } from "@/store/redux/features/todos/todoSlice";
 import { GroupedTodo } from "@/types/todos";
 import { useEffect, useMemo } from "react";
 
-export default function TodosContainer() {
+interface TodosContainerProps {
+  date: string;
+}
+
+export default function TodosContainer({ date }: TodosContainerProps) {
   const dispatch = useAppDispatch();
   const todosData = useAppSelector((state) => state.todos.data);
-  const today = new Date().toISOString().split("T")[0];
-  const { data: todosListData, isLoading, error } = useTodosByDate(today);
+  const { data: todosListData, isLoading, error } = useTodosByDate(date);
 
   // API 데이터가 변경되면 Redux에 저장
   useEffect(() => {
@@ -22,7 +25,7 @@ export default function TodosContainer() {
 
   // todos를 운동별로 그룹화
   const groupedTodos = useMemo(() => {
-    if (!todosData || !todosData.exercises || todosData.isDone) return [];
+    if (!todosData || !todosData.exercises) return [];
 
     const map = new Map<number, GroupedTodo>();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #47

## 📝작업 내용

> 원래 코드에서는 today의 기준을 ISO 시간으로 하여 특정 시간대에서 세부화면으로 넘어갈 시,
> 당일이 아닌 전날의 운동 항목이 렌더링되는 문제를 수정하였습니다.
> TodoContainer.tsx에서 isDone이 렌더링 조건에 포함되어, 
> isDone인 날짜의 운동 항목이 세부화면에서 렌더링되지 않는 문제를 수정하였습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 시연 영상 찍으실 때 위와 같은 문제 발생 시 머지하신 후에 다시 진행해보시면 좋을 것 같습니다.
> (위와 같은 상황이 발생하지 않는 경우 나중에 하셔도 무방합니다.)
